### PR TITLE
perf: remove unnecessary setup-environment job

### DIFF
--- a/.github/workflows/test-contract.yml
+++ b/.github/workflows/test-contract.yml
@@ -15,16 +15,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  setup-environment:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Set up environment
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y curl
-
   sozo-test:
-    needs: [setup-environment]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -58,7 +49,6 @@ jobs:
           cd contracts && sozo test
 
   scarb-fmt:
-    needs: [setup-environment]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/contracts/src/constants/adventurer.cairo
+++ b/contracts/src/constants/adventurer.cairo
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-// Starting Setting
+// Starting Settings
 pub const STARTING_GOLD: u8 = 40;
 pub const STARTING_HEALTH: u8 = 100;
 


### PR DESCRIPTION
## Summary
Removes the setup-environment job that only installs curl, which is already pre-installed on Ubuntu runners.

## Expected Impact
- Eliminates ~12s job execution time
- Removes dependency wait time between jobs
- Total expected savings: ~30-45s

Part of workflow optimization efforts tracked in workflow_optimizations.md