### PR TITLE
perf: add caching for Dojo binary and Scarb dependencies

### DIFF
--- a/.github/workflows/test-contract.yml
+++ b/.github/workflows/test-contract.yml
@@ -15,53 +15,39 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  sozo-test:
+  test-and-format:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Extract dojo version
+      - name: Extract tool versions
         run: |
           DOJO_VERSION=$(grep '^dojo ' .tool-versions | awk '{print $2}')
           echo "DOJO_VERSION=$DOJO_VERSION" >> "$GITHUB_ENV"
-
-      - name: Extract scarb version
-        run: |
           SCARB_VERSION=$(grep '^scarb ' .tool-versions | awk '{print $2}')
           echo "SCARB_VERSION=$SCARB_VERSION" >> "$GITHUB_ENV"
-
-      - name: Download Dojo release artifact
-        run: |
-          curl -L -o dojo-linux-x86_64.tar.gz https://github.com/dojoengine/dojo/releases/download/v${{ env.DOJO_VERSION }}/dojo_v${{ env.DOJO_VERSION }}_linux_amd64.tar.gz
-          tar -xzf dojo-linux-x86_64.tar.gz
-          sudo mv sozo /usr/local/bin/
 
       - name: Setup Scarb
         uses: software-mansion/setup-scarb@v1
         with:
           scarb-version: ${{ env.SCARB_VERSION }}
+
+      - name: Check formatting
+        run: |
+          cd contracts && scarb fmt --check
+
+      - name: Download and install Dojo
+        run: |
+          curl -L -o dojo-linux-x86_64.tar.gz https://github.com/dojoengine/dojo/releases/download/v${{ env.DOJO_VERSION }}/dojo_v${{ env.DOJO_VERSION }}_linux_amd64.tar.gz
+          tar -xzf dojo-linux-x86_64.tar.gz
+          sudo mv sozo /usr/local/bin/
+
       - name: Run Dojo Build
         run: |
           cd contracts && sozo build
+
       - name: Run Tests
         run: |
           cd contracts && sozo test
-
-  scarb-fmt:
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Extract scarb version
-        run: |
-          SCARB_VERSION=$(grep '^scarb ' .tool-versions | awk '{print $2}')
-          echo "SCARB_VERSION=$SCARB_VERSION" >> "$GITHUB_ENV"
-
-      - uses: software-mansion/setup-scarb@v1
-        with:
-          scarb-version: ${{ env.SCARB_VERSION }}
-
-      - run: cd contracts && scarb fmt --check

--- a/.github/workflows/test-contract.yml
+++ b/.github/workflows/test-contract.yml
@@ -15,16 +15,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  setup-environment:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Set up environment
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y curl
-
   sozo-test:
-    needs: [setup-environment]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -58,7 +49,6 @@ jobs:
           cd contracts && sozo test
 
   scarb-fmt:
-    needs: [setup-environment]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/test-contract.yml
+++ b/.github/workflows/test-contract.yml
@@ -33,20 +33,38 @@ jobs:
           SCARB_VERSION=$(grep '^scarb ' .tool-versions | awk '{print $2}')
           echo "SCARB_VERSION=$SCARB_VERSION" >> "$GITHUB_ENV"
 
+      - name: Cache Dojo binary
+        id: cache-dojo
+        uses: actions/cache@v4
+        with:
+          path: /usr/local/bin/sozo
+          key: dojo-${{ env.DOJO_VERSION }}-${{ runner.os }}
+
+      - name: Download and install Dojo
+        if: steps.cache-dojo.outputs.cache-hit != 'true'
+        run: |
+          curl -L -o dojo-linux-x86_64.tar.gz https://github.com/dojoengine/dojo/releases/download/v${{ env.DOJO_VERSION }}/dojo_v${{ env.DOJO_VERSION }}_linux_amd64.tar.gz
+          tar -xzf dojo-linux-x86_64.tar.gz
+          sudo mv sozo /usr/local/bin/
+
       - name: Setup Scarb
         uses: software-mansion/setup-scarb@v1
         with:
           scarb-version: ${{ env.SCARB_VERSION }}
 
+      - name: Cache Scarb packages
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.scarb
+            contracts/target
+          key: scarb-${{ runner.os }}-${{ hashFiles('contracts/Scarb.lock') }}
+          restore-keys: |
+            scarb-${{ runner.os }}-
+
       - name: Check formatting
         run: |
           cd contracts && scarb fmt --check
-
-      - name: Download and install Dojo
-        run: |
-          curl -L -o dojo-linux-x86_64.tar.gz https://github.com/dojoengine/dojo/releases/download/v${{ env.DOJO_VERSION }}/dojo_v${{ env.DOJO_VERSION }}_linux_amd64.tar.gz
-          tar -xzf dojo-linux-x86_64.tar.gz
-          sudo mv sozo /usr/local/bin/
 
       - name: Run Dojo Build
         run: |

--- a/.github/workflows/test-contract.yml
+++ b/.github/workflows/test-contract.yml
@@ -17,6 +17,7 @@ concurrency:
 jobs:
   sozo-test:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -50,6 +51,7 @@ jobs:
 
   scarb-fmt:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/test-contract.yml
+++ b/.github/workflows/test-contract.yml
@@ -2,13 +2,17 @@ name: test-contracts
 
 on:
   pull_request:
-    paths-ignore:
-      - "ui/**"
-      - "**/manifest.json"
-      - "pnpm-lock.yaml"
+    paths:
+      - "contracts/**"
+      - ".tool-versions"
+      - ".github/workflows/test-contract.yml"
   push:
     branches:
       - main
+    paths:
+      - "contracts/**"
+      - ".tool-versions"
+      - ".github/workflows/test-contract.yml"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/.github/workflows/test-contract.yml
+++ b/.github/workflows/test-contract.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Extract dojo version
         run: |
@@ -51,7 +51,7 @@ jobs:
   scarb-fmt:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Extract scarb version
         run: |

--- a/contracts/src/constants/adventurer.cairo
+++ b/contracts/src/constants/adventurer.cairo
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-// Starting Setting
+// Starting Settings
 pub const STARTING_GOLD: u8 = 40;
 pub const STARTING_HEALTH: u8 = 100;
 


### PR DESCRIPTION
## Summary
Adds caching for Dojo binary and Scarb dependencies to reduce download and compilation time.

## Changes
- Cache Dojo binary after download
- Cache Scarb packages and build artifacts
- Content-based cache keys for proper invalidation
- Restore keys for partial cache hits

## Expected Impact
- First run: No change (builds cache)
- Subsequent runs: ~30-60s savings from cached dependencies
- Dojo download: ~20-30s saved
- Scarb compilation: Variable savings based on changes

Part of workflow optimization efforts tracked in workflow_optimizations.md