### PR TITLE
feat: provide verbose adventurer model for onchain renderers

### DIFF
--- a/contracts/src/models/adventurer/adventurer.cairo
+++ b/contracts/src/models/adventurer/adventurer.cairo
@@ -21,8 +21,8 @@ use death_mountain::constants::loot::ItemSuffix::{
     of_Rage, of_Reflection, of_Skill, of_Titans, of_Vitriol, of_the_Fox, of_the_Twins,
 };
 use death_mountain::constants::loot::{ItemId, SUFFIX_UNLOCK_GREATNESS};
-use death_mountain::models::adventurer::bag::{Bag, IBag};
-use death_mountain::models::adventurer::equipment::{Equipment, IEquipment, ImplEquipment};
+use death_mountain::models::adventurer::bag::{Bag, BagVerbose, IBag, ImplBag};
+use death_mountain::models::adventurer::equipment::{Equipment, EquipmentVerbose, IEquipment, ImplEquipment};
 use death_mountain::models::adventurer::item::{IItemPrimitive, ImplItem, Item};
 use death_mountain::models::adventurer::stats::{IStat, ImplStats, Stats};
 use death_mountain::models::beast::{Beast};
@@ -43,6 +43,23 @@ pub struct Adventurer {
     pub equipment: Equipment, // 128 bits
     pub item_specials_seed: u16, // 16 bits
     pub action_count: u16,
+}
+
+// for clients and renderers
+#[derive(Introspect, Drop, Serde)]
+pub struct AdventurerVerbose {
+    pub name: ByteArray,
+    pub health: u16,
+    pub xp: u16,
+    pub level: u8,
+    pub gold: u16,
+    pub beast_health: u16,
+    pub stat_upgrades_available: u8,
+    pub stats: Stats,
+    pub equipment: EquipmentVerbose,
+    pub item_specials_seed: u16,
+    pub action_count: u16,
+    pub bag: BagVerbose,
 }
 
 #[derive(Drop, Serde)]

--- a/contracts/src/models/adventurer/bag.cairo
+++ b/contracts/src/models/adventurer/bag.cairo
@@ -3,7 +3,7 @@
 use core::panic_with_felt252;
 use core::traits::DivRem;
 use death_mountain::constants::loot::SUFFIX_UNLOCK_GREATNESS;
-use death_mountain::models::adventurer::item::{IItemPrimitive, ImplItem, Item};
+use death_mountain::models::adventurer::item::{IItemPrimitive, ImplItem, Item, ItemVerbose};
 use death_mountain::models::adventurer::stats::{ImplStats, Stats};
 use death_mountain::models::loot::ImplLoot;
 
@@ -27,6 +27,26 @@ pub struct Bag { // 240 bits
     pub item_14: Item,
     pub item_15: Item,
     pub mutated: bool,
+}
+
+// for clients and renderers
+#[derive(Introspect, Drop, Copy, Serde)]
+pub struct BagVerbose {
+    pub item_1: ItemVerbose,
+    pub item_2: ItemVerbose,
+    pub item_3: ItemVerbose,
+    pub item_4: ItemVerbose,
+    pub item_5: ItemVerbose,
+    pub item_6: ItemVerbose,
+    pub item_7: ItemVerbose,
+    pub item_8: ItemVerbose,
+    pub item_9: ItemVerbose,
+    pub item_10: ItemVerbose,
+    pub item_11: ItemVerbose,
+    pub item_12: ItemVerbose,
+    pub item_13: ItemVerbose,
+    pub item_14: ItemVerbose,
+    pub item_15: ItemVerbose,
 }
 
 #[generate_trait]
@@ -524,6 +544,29 @@ pub impl ImplBag of IBag {
         stats
     }
 }
+
+impl BagIntoBagVerbose of Into<Bag, BagVerbose> {
+    fn into(self: Bag) -> BagVerbose {
+        BagVerbose {
+            item_1: self.item_1.into(),
+            item_2: self.item_2.into(),
+            item_3: self.item_3.into(),
+            item_4: self.item_4.into(),
+            item_5: self.item_5.into(),
+            item_6: self.item_6.into(),
+            item_7: self.item_7.into(),
+            item_8: self.item_8.into(),
+            item_9: self.item_9.into(),
+            item_10: self.item_10.into(),
+            item_11: self.item_11.into(),
+            item_12: self.item_12.into(),
+            item_13: self.item_13.into(),
+            item_14: self.item_14.into(),
+            item_15: self.item_15.into(),
+        }
+    }
+}
+
 const TWO_POW_21: u256 = 0x200000;
 const TWO_POW_16: u256 = 0x10000;
 const TWO_POW_32: u256 = 0x100000000;
@@ -546,8 +589,9 @@ const TWO_POW_240: u256 = 0x1000000000000000000000000000000000000000000000000000
 // ---------------------------
 #[cfg(test)]
 mod tests {
+    use death_mountain::constants::combat::CombatEnums::{Slot, Tier, Type};
     use death_mountain::constants::loot::{ItemId, SUFFIX_UNLOCK_GREATNESS};
-    use death_mountain::models::adventurer::bag::{Bag, ImplBag};
+    use death_mountain::models::adventurer::bag::{Bag, BagVerbose, ImplBag};
     use death_mountain::models::adventurer::item::{Item};
 
     #[test]
@@ -1222,5 +1266,729 @@ mod tests {
         };
 
         assert!(empty_bag.has_specials() == false, "Empty bag should not have specials");
+    }
+
+    #[test]
+    #[available_gas(637800)]
+    fn test_bag_into_bag_verbose_gas() {
+        let empty_bag = Bag {
+            item_1: Item { id: 1, xp: 100 },
+            item_2: Item { id: 2, xp: 101 },
+            item_3: Item { id: 3, xp: 102 },
+            item_4: Item { id: 4, xp: 103 },
+            item_5: Item { id: 5, xp: 104 },
+            item_6: Item { id: 6, xp: 105 },
+            item_7: Item { id: 7, xp: 106 },
+            item_8: Item { id: 8, xp: 107 },
+            item_9: Item { id: 9, xp: 108 },
+            item_10: Item { id: 10, xp: 109 },
+            item_11: Item { id: 11, xp: 110 },
+            item_12: Item { id: 12, xp: 111 },
+            item_13: Item { id: 13, xp: 112 },
+            item_14: Item { id: 14, xp: 113 },
+            item_15: Item { id: 15, xp: 114 },
+            mutated: false,
+        };
+        let _verbose_bag: BagVerbose = empty_bag.into();
+    }
+
+
+    #[test]
+    fn test_bag_into_bag_verbose_empty_bag() {
+        let empty_bag = Bag {
+            item_1: Item { id: 0, xp: 0 },
+            item_2: Item { id: 0, xp: 0 },
+            item_3: Item { id: 0, xp: 0 },
+            item_4: Item { id: 0, xp: 0 },
+            item_5: Item { id: 0, xp: 0 },
+            item_6: Item { id: 0, xp: 0 },
+            item_7: Item { id: 0, xp: 0 },
+            item_8: Item { id: 0, xp: 0 },
+            item_9: Item { id: 0, xp: 0 },
+            item_10: Item { id: 0, xp: 0 },
+            item_11: Item { id: 0, xp: 0 },
+            item_12: Item { id: 0, xp: 0 },
+            item_13: Item { id: 0, xp: 0 },
+            item_14: Item { id: 0, xp: 0 },
+            item_15: Item { id: 0, xp: 0 },
+            mutated: false,
+        };
+
+        let verbose_bag: BagVerbose = empty_bag.into();
+
+        assert!(
+            verbose_bag.item_1.name == 0,
+            "item1 wrong name. expected {:?}, actual {:?}",
+            'None',
+            verbose_bag.item_1.name,
+        );
+        assert!(verbose_bag.item_1.id == 0, "item1 wrong id. expected 0, actual {:?}", verbose_bag.item_1.id);
+        assert!(verbose_bag.item_1.xp == 0, "item1 wrong xp. expected 0, actual {:?}", verbose_bag.item_1.xp);
+        assert(verbose_bag.item_1.tier == Tier::None, 'item1 wrong tier');
+        assert(verbose_bag.item_1.item_type == Type::None, 'item1 wrong type');
+        assert(verbose_bag.item_1.slot == Slot::None, 'item1 wrong slot');
+        assert(verbose_bag.item_2.name == 0, 'item2 wrong name');
+
+        assert!(
+            verbose_bag.item_2.name == 0,
+            "item2 wrong name. expected {:?}, actual {:?}",
+            'None',
+            verbose_bag.item_2.name,
+        );
+        assert!(verbose_bag.item_2.id == 0, "item2 wrong id. expected 0, actual {:?}", verbose_bag.item_2.id);
+        assert!(verbose_bag.item_2.xp == 0, "item2 wrong xp. expected 0, actual {:?}", verbose_bag.item_2.xp);
+        assert(verbose_bag.item_2.tier == Tier::None, 'item2 wrong tier');
+        assert(verbose_bag.item_2.item_type == Type::None, 'item2 wrong type');
+        assert(verbose_bag.item_2.slot == Slot::None, 'item2 wrong slot');
+
+        assert!(
+            verbose_bag.item_3.name == 0,
+            "item3 wrong name. expected {:?}, actual {:?}",
+            'None',
+            verbose_bag.item_3.name,
+        );
+        assert!(verbose_bag.item_3.id == 0, "item3 wrong id. expected 0, actual {:?}", verbose_bag.item_3.id);
+        assert!(verbose_bag.item_3.xp == 0, "item3 wrong xp. expected 0, actual {:?}", verbose_bag.item_3.xp);
+        assert(verbose_bag.item_3.tier == Tier::None, 'item3 wrong tier');
+        assert(verbose_bag.item_3.item_type == Type::None, 'item3 wrong type');
+        assert(verbose_bag.item_3.slot == Slot::None, 'item3 wrong slot');
+
+        assert!(
+            verbose_bag.item_4.name == 0,
+            "item4 wrong name. expected {:?}, actual {:?}",
+            'None',
+            verbose_bag.item_4.name,
+        );
+        assert!(verbose_bag.item_4.id == 0, "item4 wrong id. expected 0, actual {:?}", verbose_bag.item_4.id);
+        assert!(verbose_bag.item_4.xp == 0, "item4 wrong xp. expected 0, actual {:?}", verbose_bag.item_4.xp);
+        assert(verbose_bag.item_4.tier == Tier::None, 'item4 wrong tier');
+        assert(verbose_bag.item_4.item_type == Type::None, 'item4 wrong type');
+        assert(verbose_bag.item_4.slot == Slot::None, 'item4 wrong slot');
+
+        assert!(
+            verbose_bag.item_5.name == 0,
+            "item5 wrong name. expected {:?}, actual {:?}",
+            'None',
+            verbose_bag.item_5.name,
+        );
+        assert!(verbose_bag.item_5.id == 0, "item5 wrong id. expected 0, actual {:?}", verbose_bag.item_5.id);
+        assert!(verbose_bag.item_5.xp == 0, "item5 wrong xp. expected 0, actual {:?}", verbose_bag.item_5.xp);
+        assert(verbose_bag.item_5.tier == Tier::None, 'item5 wrong tier');
+        assert(verbose_bag.item_5.item_type == Type::None, 'item5 wrong type');
+        assert(verbose_bag.item_5.slot == Slot::None, 'item5 wrong slot');
+
+        assert!(
+            verbose_bag.item_6.name == 0,
+            "item6 wrong name. expected {:?}, actual {:?}",
+            'None',
+            verbose_bag.item_6.name,
+        );
+        assert!(verbose_bag.item_6.id == 0, "item6 wrong id. expected 0, actual {:?}", verbose_bag.item_6.id);
+        assert!(verbose_bag.item_6.xp == 0, "item6 wrong xp. expected 0, actual {:?}", verbose_bag.item_6.xp);
+        assert(verbose_bag.item_6.tier == Tier::None, 'item6 wrong tier');
+        assert(verbose_bag.item_6.item_type == Type::None, 'item6 wrong type');
+        assert(verbose_bag.item_6.slot == Slot::None, 'item6 wrong slot');
+
+        assert!(
+            verbose_bag.item_7.name == 0,
+            "item7 wrong name. expected {:?}, actual {:?}",
+            'None',
+            verbose_bag.item_7.name,
+        );
+        assert!(verbose_bag.item_7.id == 0, "item7 wrong id. expected 0, actual {:?}", verbose_bag.item_7.id);
+        assert!(verbose_bag.item_7.xp == 0, "item7 wrong xp. expected 0, actual {:?}", verbose_bag.item_7.xp);
+        assert(verbose_bag.item_7.tier == Tier::None, 'item7 wrong tier');
+        assert(verbose_bag.item_7.item_type == Type::None, 'item7 wrong type');
+        assert(verbose_bag.item_7.slot == Slot::None, 'item7 wrong slot');
+
+        assert!(
+            verbose_bag.item_8.name == 0,
+            "item8 wrong name. expected {:?}, actual {:?}",
+            'None',
+            verbose_bag.item_8.name,
+        );
+        assert!(verbose_bag.item_8.id == 0, "item8 wrong id. expected 0, actual {:?}", verbose_bag.item_8.id);
+        assert!(verbose_bag.item_8.xp == 0, "item8 wrong xp. expected 0, actual {:?}", verbose_bag.item_8.xp);
+        assert(verbose_bag.item_8.tier == Tier::None, 'item8 wrong tier');
+        assert(verbose_bag.item_8.item_type == Type::None, 'item8 wrong type');
+        assert(verbose_bag.item_8.slot == Slot::None, 'item8 wrong slot');
+
+        assert!(
+            verbose_bag.item_9.name == 0,
+            "item9 wrong name. expected {:?}, actual {:?}",
+            'None',
+            verbose_bag.item_9.name,
+        );
+        assert!(verbose_bag.item_9.id == 0, "item9 wrong id. expected 0, actual {:?}", verbose_bag.item_9.id);
+        assert!(verbose_bag.item_9.xp == 0, "item9 wrong xp. expected 0, actual {:?}", verbose_bag.item_9.xp);
+        assert(verbose_bag.item_9.tier == Tier::None, 'item9 wrong tier');
+        assert(verbose_bag.item_9.item_type == Type::None, 'item9 wrong type');
+        assert(verbose_bag.item_9.slot == Slot::None, 'item9 wrong slot');
+
+        assert!(
+            verbose_bag.item_10.name == 0,
+            "item10 wrong name. expected {:?}, actual {:?}",
+            'None',
+            verbose_bag.item_10.name,
+        );
+        assert!(verbose_bag.item_10.id == 0, "item10 wrong id. expected 0, actual {:?}", verbose_bag.item_10.id);
+        assert!(verbose_bag.item_10.xp == 0, "item10 wrong xp. expected 0, actual {:?}", verbose_bag.item_10.xp);
+        assert(verbose_bag.item_10.tier == Tier::None, 'item10 wrong tier');
+        assert(verbose_bag.item_10.item_type == Type::None, 'item10 wrong type');
+        assert(verbose_bag.item_10.slot == Slot::None, 'item10 wrong slot');
+
+        assert!(
+            verbose_bag.item_11.name == 0,
+            "item11 wrong name. expected {:?}, actual {:?}",
+            'None',
+            verbose_bag.item_11.name,
+        );
+        assert!(verbose_bag.item_11.id == 0, "item11 wrong id. expected 0, actual {:?}", verbose_bag.item_11.id);
+        assert!(verbose_bag.item_11.xp == 0, "item11 wrong xp. expected 0, actual {:?}", verbose_bag.item_11.xp);
+        assert(verbose_bag.item_11.tier == Tier::None, 'item11 wrong tier');
+        assert(verbose_bag.item_11.item_type == Type::None, 'item11 wrong type');
+        assert(verbose_bag.item_11.slot == Slot::None, 'item11 wrong slot');
+
+        assert!(
+            verbose_bag.item_12.name == 0,
+            "item12 wrong name. expected {:?}, actual {:?}",
+            'None',
+            verbose_bag.item_12.name,
+        );
+        assert!(verbose_bag.item_12.id == 0, "item12 wrong id. expected 0, actual {:?}", verbose_bag.item_12.id);
+        assert!(verbose_bag.item_12.xp == 0, "item12 wrong xp. expected 0, actual {:?}", verbose_bag.item_12.xp);
+        assert(verbose_bag.item_12.tier == Tier::None, 'item12 wrong tier');
+        assert(verbose_bag.item_12.item_type == Type::None, 'item12 wrong type');
+        assert(verbose_bag.item_12.slot == Slot::None, 'item12 wrong slot');
+
+        assert!(
+            verbose_bag.item_13.name == 0,
+            "item13 wrong name. expected {:?}, actual {:?}",
+            'None',
+            verbose_bag.item_13.name,
+        );
+        assert!(verbose_bag.item_13.id == 0, "item13 wrong id. expected 0, actual {:?}", verbose_bag.item_13.id);
+        assert!(verbose_bag.item_13.xp == 0, "item13 wrong xp. expected 0, actual {:?}", verbose_bag.item_13.xp);
+        assert(verbose_bag.item_13.tier == Tier::None, 'item13 wrong tier');
+        assert(verbose_bag.item_13.item_type == Type::None, 'item13 wrong type');
+        assert(verbose_bag.item_13.slot == Slot::None, 'item13 wrong slot');
+
+        assert!(
+            verbose_bag.item_14.name == 0,
+            "item14 wrong name. expected {:?}, actual {:?}",
+            'None',
+            verbose_bag.item_14.name,
+        );
+        assert!(verbose_bag.item_14.id == 0, "item14 wrong id. expected 0, actual {:?}", verbose_bag.item_14.id);
+        assert!(verbose_bag.item_14.xp == 0, "item14 wrong xp. expected 0, actual {:?}", verbose_bag.item_14.xp);
+        assert(verbose_bag.item_14.tier == Tier::None, 'item14 wrong tier');
+        assert(verbose_bag.item_14.item_type == Type::None, 'item14 wrong type');
+        assert(verbose_bag.item_14.slot == Slot::None, 'item14 wrong slot');
+
+        assert!(
+            verbose_bag.item_15.name == 0,
+            "item15 wrong name. expected {:?}, actual {:?}",
+            'None',
+            verbose_bag.item_15.name,
+        );
+        assert!(verbose_bag.item_15.id == 0, "item15 wrong id. expected 0, actual {:?}", verbose_bag.item_15.id);
+        assert!(verbose_bag.item_15.xp == 0, "item15 wrong xp. expected 0, actual {:?}", verbose_bag.item_15.xp);
+        assert(verbose_bag.item_15.tier == Tier::None, 'item15 wrong tier');
+        assert(verbose_bag.item_15.item_type == Type::None, 'item15 wrong type');
+        assert(verbose_bag.item_15.slot == Slot::None, 'item15 wrong slot');
+    }
+
+    #[test]
+    fn test_bag_into_bag_verbose_full_bag() {
+        let full_bag = Bag {
+            item_1: Item { id: ItemId::Katana, xp: 100 },
+            item_2: Item { id: ItemId::DemonCrown, xp: 200 },
+            item_3: Item { id: ItemId::SilkRobe, xp: 300 },
+            item_4: Item { id: ItemId::SilverRing, xp: 400 },
+            item_5: Item { id: ItemId::GhostWand, xp: 500 },
+            item_6: Item { id: ItemId::LeatherGloves, xp: 50 },
+            item_7: Item { id: ItemId::SilkGloves, xp: 75 },
+            item_8: Item { id: ItemId::LinenGloves, xp: 80 },
+            item_9: Item { id: ItemId::Crown, xp: 150 },
+            item_10: Item { id: ItemId::DivineSlippers, xp: 250 },
+            item_11: Item { id: ItemId::Warhammer, xp: 350 },
+            item_12: Item { id: ItemId::Quarterstaff, xp: 450 },
+            item_13: Item { id: ItemId::Amulet, xp: 130 },
+            item_14: Item { id: ItemId::BronzeRing, xp: 225 },
+            item_15: Item { id: ItemId::Pendant, xp: 150 },
+            mutated: true,
+        };
+
+        let verbose_bag: BagVerbose = full_bag.into();
+
+        assert!(
+            verbose_bag.item_1.id == ItemId::Katana,
+            "wrong item1 id. expected {:?}, actual {:?}",
+            ItemId::Katana,
+            verbose_bag.item_1.id,
+        );
+        assert!(verbose_bag.item_1.xp == 100, "wrong item1 xp. expected 100, actual {:?}", verbose_bag.item_1.xp);
+        assert!(
+            verbose_bag.item_1.name == 'Katana',
+            "wrong item1 name. expected {:?}, actual {:?}",
+            'Katana',
+            verbose_bag.item_1.name,
+        );
+        assert(verbose_bag.item_1.tier == Tier::T1, 'wrong item1 tier');
+        assert(verbose_bag.item_1.item_type == Type::Blade_or_Hide, 'wrong item1 type');
+        assert(verbose_bag.item_1.slot == Slot::Weapon, 'wrong item1 slot');
+
+        assert!(
+            verbose_bag.item_2.id == ItemId::DemonCrown,
+            "wrong item2 id. expected {:?}, actual {:?}",
+            ItemId::DemonCrown,
+            verbose_bag.item_2.id,
+        );
+        assert!(verbose_bag.item_2.xp == 200, "wrong item2 xp. expected 200, actual {:?}", verbose_bag.item_2.xp);
+        assert!(
+            verbose_bag.item_2.name == 'Demon Crown',
+            "wrong item2 name. expected {:?}, actual {:?}",
+            'DemonCrown',
+            verbose_bag.item_2.name,
+        );
+        assert(verbose_bag.item_2.tier == Tier::T1, 'wrong item2 tier');
+        assert(verbose_bag.item_2.item_type == Type::Blade_or_Hide, 'wrong item2 type');
+        assert(verbose_bag.item_2.slot == Slot::Head, 'wrong item2 slot');
+
+        assert!(
+            verbose_bag.item_3.id == ItemId::SilkRobe,
+            "wrong item3 id. expected {:?}, actual {:?}",
+            ItemId::SilkRobe,
+            verbose_bag.item_3.id,
+        );
+        assert!(verbose_bag.item_3.xp == 300, "wrong item3 xp. expected 300, actual {:?}", verbose_bag.item_3.xp);
+        assert!(
+            verbose_bag.item_3.name == 'Silk Robe',
+            "wrong item3 name. expected {:?}, actual {:?}",
+            'SilkRobe',
+            verbose_bag.item_3.name,
+        );
+        assert(verbose_bag.item_3.tier == Tier::T2, 'wrong item3 tier');
+        assert(verbose_bag.item_3.item_type == Type::Magic_or_Cloth, 'wrong item3 type');
+        assert(verbose_bag.item_3.slot == Slot::Chest, 'wrong item3 slot');
+
+        assert!(
+            verbose_bag.item_4.id == ItemId::SilverRing,
+            "wrong item4 id. expected {:?}, actual {:?}",
+            ItemId::SilverRing,
+            verbose_bag.item_4.id,
+        );
+        assert!(verbose_bag.item_4.xp == 400, "wrong item4 xp. expected 400, actual {:?}", verbose_bag.item_4.xp);
+        assert!(
+            verbose_bag.item_4.name == 'Silver Ring',
+            "wrong item4 name. expected {:?}, actual {:?}",
+            'SilverRing',
+            verbose_bag.item_4.name,
+        );
+        assert(verbose_bag.item_4.tier == Tier::T2, 'wrong item4 tier');
+        assert(verbose_bag.item_4.item_type == Type::Ring, 'wrong item4 type');
+        assert(verbose_bag.item_4.slot == Slot::Ring, 'wrong item4 slot');
+
+        assert!(
+            verbose_bag.item_5.id == ItemId::GhostWand,
+            "wrong item5 id. expected {:?}, actual {:?}",
+            ItemId::GhostWand,
+            verbose_bag.item_5.id,
+        );
+        assert!(verbose_bag.item_5.xp == 500, "wrong item5 xp. expected 500, actual {:?}", verbose_bag.item_5.xp);
+        assert!(
+            verbose_bag.item_5.name == 'Ghost Wand',
+            "wrong item5 name. expected {:?}, actual {:?}",
+            'GhostWand',
+            verbose_bag.item_5.name,
+        );
+        assert(verbose_bag.item_5.tier == Tier::T1, 'wrong item5 tier');
+        assert(verbose_bag.item_5.item_type == Type::Magic_or_Cloth, 'wrong item5 type');
+        assert(verbose_bag.item_5.slot == Slot::Weapon, 'wrong item5 slot');
+
+        assert!(
+            verbose_bag.item_6.id == ItemId::LeatherGloves,
+            "wrong item6 id. expected {:?}, actual {:?}",
+            ItemId::LeatherGloves,
+            verbose_bag.item_6.id,
+        );
+        assert!(verbose_bag.item_6.xp == 50, "wrong item6 xp. expected 50, actual {:?}", verbose_bag.item_6.xp);
+        assert!(
+            verbose_bag.item_6.name == 'Leather Gloves',
+            "wrong item6 name. expected {:?}, actual {:?}",
+            'LeatherGloves',
+            verbose_bag.item_6.name,
+        );
+        assert(verbose_bag.item_6.tier == Tier::T5, 'wrong item6 tier');
+        assert(verbose_bag.item_6.item_type == Type::Blade_or_Hide, 'wrong item6 type');
+        assert(verbose_bag.item_6.slot == Slot::Hand, 'wrong item6 slot');
+
+        assert!(
+            verbose_bag.item_7.id == ItemId::SilkGloves,
+            "wrong item7 id. expected {:?}, actual {:?}",
+            ItemId::SilkGloves,
+            verbose_bag.item_7.id,
+        );
+        assert!(verbose_bag.item_7.xp == 75, "wrong item7 xp. expected 75, actual {:?}", verbose_bag.item_7.xp);
+        assert!(
+            verbose_bag.item_7.name == 'Silk Gloves',
+            "wrong item7 name. expected {:?}, actual {:?}",
+            'SilkGloves',
+            verbose_bag.item_7.name,
+        );
+        assert(verbose_bag.item_7.tier == Tier::T2, 'wrong item7 tier');
+        assert(verbose_bag.item_7.item_type == Type::Magic_or_Cloth, 'wrong item7 type');
+        assert(verbose_bag.item_7.slot == Slot::Hand, 'wrong item7 slot');
+
+        assert!(
+            verbose_bag.item_8.id == ItemId::LinenGloves,
+            "wrong item8 id. expected {:?}, actual {:?}",
+            ItemId::LinenGloves,
+            verbose_bag.item_8.id,
+        );
+        assert!(verbose_bag.item_8.xp == 80, "wrong item8 xp. expected 80, actual {:?}", verbose_bag.item_8.xp);
+        assert!(
+            verbose_bag.item_8.name == 'Linen Gloves',
+            "wrong item8 name. expected {:?}, actual {:?}",
+            'LinenGloves',
+            verbose_bag.item_8.name,
+        );
+        assert(verbose_bag.item_8.tier == Tier::T4, 'wrong item8 tier');
+        assert(verbose_bag.item_8.item_type == Type::Magic_or_Cloth, 'wrong item8 type');
+        assert(verbose_bag.item_8.slot == Slot::Hand, 'wrong item8 slot');
+
+        assert!(
+            verbose_bag.item_9.id == ItemId::Crown,
+            "wrong item9 id. expected {:?}, actual {:?}",
+            ItemId::Crown,
+            verbose_bag.item_9.id,
+        );
+        assert!(verbose_bag.item_9.xp == 150, "wrong item9 xp. expected 150, actual {:?}", verbose_bag.item_9.xp);
+        assert!(
+            verbose_bag.item_9.name == 'Crown',
+            "wrong item9 name. expected {:?}, actual {:?}",
+            'Crown',
+            verbose_bag.item_9.name,
+        );
+        assert(verbose_bag.item_9.tier == Tier::T1, 'wrong item9 tier');
+        assert(verbose_bag.item_9.item_type == Type::Magic_or_Cloth, 'wrong item9 type');
+        assert(verbose_bag.item_9.slot == Slot::Head, 'wrong item9 slot');
+
+        assert!(
+            verbose_bag.item_10.id == ItemId::DivineSlippers,
+            "wrong item10 id. expected {:?}, actual {:?}",
+            ItemId::DivineSlippers,
+            verbose_bag.item_10.id,
+        );
+        assert!(verbose_bag.item_10.xp == 250, "wrong item10 xp. expected 250, actual {:?}", verbose_bag.item_10.xp);
+        assert!(
+            verbose_bag.item_10.name == 'Divine Slippers',
+            "wrong item10 name. expected {:?}, actual {:?}",
+            'DivineSlippers',
+            verbose_bag.item_10.name,
+        );
+        assert(verbose_bag.item_10.tier == Tier::T1, 'wrong item10 tier');
+        assert(verbose_bag.item_10.item_type == Type::Magic_or_Cloth, 'wrong item10 type');
+        assert(verbose_bag.item_10.slot == Slot::Foot, 'wrong item10 slot');
+
+        assert!(
+            verbose_bag.item_11.id == ItemId::Warhammer,
+            "wrong item11 id. expected {:?}, actual {:?}",
+            ItemId::Warhammer,
+            verbose_bag.item_11.id,
+        );
+        assert!(verbose_bag.item_11.xp == 350, "wrong item11 xp. expected 350, actual {:?}", verbose_bag.item_11.xp);
+        assert!(
+            verbose_bag.item_11.name == 'Warhammer',
+            "wrong item11 name. expected {:?}, actual {:?}",
+            'Warhammer',
+            verbose_bag.item_11.name,
+        );
+        assert(verbose_bag.item_11.tier == Tier::T1, 'wrong item11 tier');
+        assert(verbose_bag.item_11.item_type == Type::Bludgeon_or_Metal, 'wrong item11 type');
+        assert(verbose_bag.item_11.slot == Slot::Weapon, 'wrong item11 slot');
+
+        assert!(
+            verbose_bag.item_12.id == ItemId::Quarterstaff,
+            "wrong item12 id. expected {:?}, actual {:?}",
+            ItemId::Quarterstaff,
+            verbose_bag.item_12.id,
+        );
+        assert!(verbose_bag.item_12.xp == 450, "wrong item12 xp. expected 450, actual {:?}", verbose_bag.item_12.xp);
+        assert!(
+            verbose_bag.item_12.name == 'Quarterstaff',
+            "wrong item12 name. expected {:?}, actual {:?}",
+            'Quarterstaff',
+            verbose_bag.item_12.name,
+        );
+        assert(verbose_bag.item_12.tier == Tier::T2, 'wrong item12 tier');
+        assert(verbose_bag.item_12.item_type == Type::Bludgeon_or_Metal, 'wrong item12 type');
+        assert(verbose_bag.item_12.slot == Slot::Weapon, 'wrong item12 slot');
+
+        assert!(
+            verbose_bag.item_13.id == ItemId::Amulet,
+            "wrong item13 id. expected {:?}, actual {:?}",
+            ItemId::Amulet,
+            verbose_bag.item_13.id,
+        );
+        assert!(verbose_bag.item_13.xp == 130, "wrong item13 xp. expected 130, actual {:?}", verbose_bag.item_13.xp);
+        assert!(
+            verbose_bag.item_13.name == 'Amulet',
+            "wrong item13 name. expected {:?}, actual {:?}",
+            'Amulet',
+            verbose_bag.item_13.name,
+        );
+        assert(verbose_bag.item_13.tier == Tier::T1, 'wrong item13 tier');
+        assert(verbose_bag.item_13.item_type == Type::Necklace, 'wrong item13 type');
+        assert(verbose_bag.item_13.slot == Slot::Neck, 'wrong item13 slot');
+
+        assert!(
+            verbose_bag.item_14.id == ItemId::BronzeRing,
+            "wrong item14 id. expected {:?}, actual {:?}",
+            ItemId::BronzeRing,
+            verbose_bag.item_14.id,
+        );
+        assert!(verbose_bag.item_14.xp == 225, "wrong item14 xp. expected 225, actual {:?}", verbose_bag.item_14.xp);
+        assert!(
+            verbose_bag.item_14.name == 'Bronze Ring',
+            "wrong item14 name. expected {:?}, actual {:?}",
+            'BronzeRing',
+            verbose_bag.item_14.name,
+        );
+        assert(verbose_bag.item_14.tier == Tier::T3, 'wrong item14 tier');
+        assert(verbose_bag.item_14.item_type == Type::Ring, 'wrong item14 type');
+        assert(verbose_bag.item_14.slot == Slot::Ring, 'wrong item14 slot');
+
+        assert!(
+            verbose_bag.item_15.id == ItemId::Pendant,
+            "wrong item15 id. expected {:?}, actual {:?}",
+            ItemId::Pendant,
+            verbose_bag.item_15.id,
+        );
+        assert!(verbose_bag.item_15.xp == 150, "wrong item15 xp. expected 150, actual {:?}", verbose_bag.item_15.xp);
+        assert!(
+            verbose_bag.item_15.name == 'Pendant',
+            "wrong item15 name. expected {:?}, actual {:?}",
+            'Pendant',
+            verbose_bag.item_15.name,
+        );
+        assert(verbose_bag.item_15.tier == Tier::T1, 'wrong item15 tier');
+        assert(verbose_bag.item_15.item_type == Type::Necklace, 'wrong item15 type');
+        assert(verbose_bag.item_15.slot == Slot::Neck, 'wrong item15 slot');
+    }
+
+    #[test]
+    fn test_bag_into_bag_verbose_partial_bag() {
+        let partial_bag = Bag {
+            item_1: Item { id: ItemId::Katana, xp: 10 },
+            item_2: Item { id: ItemId::Crown, xp: 20 },
+            item_3: Item { id: ItemId::SilverRing, xp: 30 },
+            item_4: Item { id: 0, xp: 0 },
+            item_5: Item { id: 0, xp: 0 },
+            item_6: Item { id: ItemId::LeatherGloves, xp: 60 },
+            item_7: Item { id: 0, xp: 0 },
+            item_8: Item { id: 0, xp: 0 },
+            item_9: Item { id: ItemId::GhostWand, xp: 90 },
+            item_10: Item { id: 0, xp: 0 },
+            item_11: Item { id: 0, xp: 0 },
+            item_12: Item { id: 0, xp: 0 },
+            item_13: Item { id: ItemId::Amulet, xp: 130 },
+            item_14: Item { id: ItemId::Pendant, xp: 150 },
+            item_15: Item { id: 0, xp: 0 },
+            mutated: false,
+        };
+
+        let verbose_bag: BagVerbose = partial_bag.into();
+
+        assert!(
+            verbose_bag.item_1.id == ItemId::Katana,
+            "wrong item1 id. expected {:?}, actual {:?}",
+            ItemId::Katana,
+            verbose_bag.item_1.id,
+        );
+        assert!(verbose_bag.item_1.xp == 10, "wrong item1 xp. expected 10, actual {:?}", verbose_bag.item_1.xp);
+        assert!(
+            verbose_bag.item_1.name == 'Katana',
+            "wrong item1 name. expected {:?}, actual {:?}",
+            'Katana',
+            verbose_bag.item_1.name,
+        );
+        assert(verbose_bag.item_1.tier == Tier::T1, 'wrong item1 tier');
+        assert(verbose_bag.item_1.item_type == Type::Blade_or_Hide, 'wrong item1 type');
+        assert(verbose_bag.item_1.slot == Slot::Weapon, 'wrong item1 slot');
+
+        assert!(
+            verbose_bag.item_2.id == ItemId::Crown,
+            "wrong item2 id. expected {:?}, actual {:?}",
+            ItemId::Crown,
+            verbose_bag.item_2.id,
+        );
+        assert!(verbose_bag.item_2.xp == 20, "wrong item2 xp. expected 20, actual {:?}", verbose_bag.item_2.xp);
+        assert!(
+            verbose_bag.item_2.name == 'Crown',
+            "wrong item2 name. expected {:?}, actual {:?}",
+            'Crown',
+            verbose_bag.item_2.name,
+        );
+        assert(verbose_bag.item_2.tier == Tier::T1, 'wrong item2 tier');
+        assert(verbose_bag.item_2.item_type == Type::Magic_or_Cloth, 'wrong item2 type');
+        assert(verbose_bag.item_2.slot == Slot::Head, 'wrong item2 slot');
+
+        assert!(
+            verbose_bag.item_3.id == ItemId::SilverRing,
+            "wrong item3 id. expected {:?}, actual {:?}",
+            ItemId::SilverRing,
+            verbose_bag.item_3.id,
+        );
+        assert!(verbose_bag.item_3.xp == 30, "wrong item3 xp. expected 30, actual {:?}", verbose_bag.item_3.xp);
+        assert!(
+            verbose_bag.item_3.name == 'Silver Ring',
+            "wrong item3 name. expected {:?}, actual {:?}",
+            'SilverRing',
+            verbose_bag.item_3.name,
+        );
+        assert(verbose_bag.item_3.tier == Tier::T2, 'wrong item3 tier');
+        assert(verbose_bag.item_3.item_type == Type::Ring, 'wrong item3 type');
+        assert(verbose_bag.item_3.slot == Slot::Ring, 'wrong item3 slot');
+
+        assert!(verbose_bag.item_4.id == 0, "wrong item4 id. expected {:?}, actual {:?}", 0, verbose_bag.item_4.id);
+        assert!(verbose_bag.item_4.xp == 0, "wrong item4 xp. expected 0, actual {:?}", verbose_bag.item_4.xp);
+        assert!(
+            verbose_bag.item_4.name == 0, "wrong item4 name. expected {:?}, actual {:?}", 0, verbose_bag.item_4.name,
+        );
+        assert(verbose_bag.item_4.tier == Tier::None, 'wrong item4 tier');
+        assert(verbose_bag.item_4.item_type == Type::None, 'wrong item4 type');
+        assert(verbose_bag.item_4.slot == Slot::None, 'wrong item4 slot');
+
+        assert!(verbose_bag.item_5.id == 0, "wrong item5 id. expected {:?}, actual {:?}", 0, verbose_bag.item_5.id);
+        assert!(verbose_bag.item_5.xp == 0, "wrong item5 xp. expected 0, actual {:?}", verbose_bag.item_5.xp);
+        assert!(
+            verbose_bag.item_5.name == 0, "wrong item5 name. expected {:?}, actual {:?}", 0, verbose_bag.item_5.name,
+        );
+        assert(verbose_bag.item_5.tier == Tier::None, 'wrong item5 tier');
+        assert(verbose_bag.item_5.item_type == Type::None, 'wrong item5 type');
+        assert(verbose_bag.item_5.slot == Slot::None, 'wrong item5 slot');
+
+        assert!(
+            verbose_bag.item_6.id == ItemId::LeatherGloves,
+            "wrong item6 id. expected {:?}, actual {:?}",
+            ItemId::LeatherGloves,
+            verbose_bag.item_6.id,
+        );
+        assert!(verbose_bag.item_6.xp == 60, "wrong item6 xp. expected 60, actual {:?}", verbose_bag.item_6.xp);
+        assert!(
+            verbose_bag.item_6.name == 'Leather Gloves',
+            "wrong item6 name. expected {:?}, actual {:?}",
+            'LeatherGloves',
+            verbose_bag.item_6.name,
+        );
+        assert(verbose_bag.item_6.tier == Tier::T5, 'wrong item6 tier');
+        assert(verbose_bag.item_6.item_type == Type::Blade_or_Hide, 'wrong item6 type');
+        assert(verbose_bag.item_6.slot == Slot::Hand, 'wrong item6 slot');
+
+        assert!(verbose_bag.item_7.id == 0, "wrong item7 id. expected {:?}, actual {:?}", 0, verbose_bag.item_7.id);
+        assert!(verbose_bag.item_7.xp == 0, "wrong item7 xp. expected 0, actual {:?}", verbose_bag.item_7.xp);
+        assert!(
+            verbose_bag.item_7.name == 0, "wrong item7 name. expected {:?}, actual {:?}", 0, verbose_bag.item_7.name,
+        );
+        assert(verbose_bag.item_7.tier == Tier::None, 'wrong item7 tier');
+        assert(verbose_bag.item_7.item_type == Type::None, 'wrong item7 type');
+        assert(verbose_bag.item_7.slot == Slot::None, 'wrong item7 slot');
+
+        assert!(verbose_bag.item_8.id == 0, "wrong item8 id. expected {:?}, actual {:?}", 0, verbose_bag.item_8.id);
+        assert!(verbose_bag.item_8.xp == 0, "wrong item8 xp. expected 0, actual {:?}", verbose_bag.item_8.xp);
+        assert!(
+            verbose_bag.item_8.name == 0, "wrong item8 name. expected {:?}, actual {:?}", 0, verbose_bag.item_8.name,
+        );
+        assert(verbose_bag.item_8.tier == Tier::None, 'wrong item8 tier');
+        assert(verbose_bag.item_8.item_type == Type::None, 'wrong item8 type');
+        assert(verbose_bag.item_8.slot == Slot::None, 'wrong item8 slot');
+
+        assert!(
+            verbose_bag.item_9.id == ItemId::GhostWand,
+            "wrong item9 id. expected {:?}, actual {:?}",
+            ItemId::GhostWand,
+            verbose_bag.item_9.id,
+        );
+        assert!(verbose_bag.item_9.xp == 90, "wrong item9 xp. expected 90, actual {:?}", verbose_bag.item_9.xp);
+        assert!(
+            verbose_bag.item_9.name == 'Ghost Wand',
+            "wrong item9 name. expected {:?}, actual {:?}",
+            'GhostWand',
+            verbose_bag.item_9.name,
+        );
+        assert(verbose_bag.item_9.tier == Tier::T1, 'wrong item9 tier');
+        assert(verbose_bag.item_9.item_type == Type::Magic_or_Cloth, 'wrong item9 type');
+        assert(verbose_bag.item_9.slot == Slot::Weapon, 'wrong item9 slot');
+
+        assert!(verbose_bag.item_10.id == 0, "wrong item10 id. expected {:?}, actual {:?}", 0, verbose_bag.item_10.id);
+        assert!(verbose_bag.item_10.xp == 0, "wrong item10 xp. expected 0, actual {:?}", verbose_bag.item_10.xp);
+        assert!(
+            verbose_bag.item_10.name == 0, "wrong item10 name. expected {:?}, actual {:?}", 0, verbose_bag.item_10.name,
+        );
+        assert(verbose_bag.item_10.tier == Tier::None, 'wrong item10 tier');
+        assert(verbose_bag.item_10.item_type == Type::None, 'wrong item10 type');
+        assert(verbose_bag.item_10.slot == Slot::None, 'wrong item10 slot');
+
+        assert!(verbose_bag.item_11.id == 0, "wrong item11 id. expected {:?}, actual {:?}", 0, verbose_bag.item_11.id);
+        assert!(verbose_bag.item_11.xp == 0, "wrong item11 xp. expected 0, actual {:?}", verbose_bag.item_11.xp);
+        assert!(
+            verbose_bag.item_11.name == 0, "wrong item11 name. expected {:?}, actual {:?}", 0, verbose_bag.item_11.name,
+        );
+        assert(verbose_bag.item_11.tier == Tier::None, 'wrong item11 tier');
+        assert(verbose_bag.item_11.item_type == Type::None, 'wrong item11 type');
+        assert(verbose_bag.item_11.slot == Slot::None, 'wrong item11 slot');
+
+        assert!(verbose_bag.item_12.id == 0, "wrong item12 id. expected {:?}, actual {:?}", 0, verbose_bag.item_12.id);
+        assert!(verbose_bag.item_12.xp == 0, "wrong item12 xp. expected 0, actual {:?}", verbose_bag.item_12.xp);
+        assert!(
+            verbose_bag.item_12.name == 0, "wrong item12 name. expected {:?}, actual {:?}", 0, verbose_bag.item_12.name,
+        );
+        assert(verbose_bag.item_12.tier == Tier::None, 'wrong item12 tier');
+        assert(verbose_bag.item_12.item_type == Type::None, 'wrong item12 type');
+        assert(verbose_bag.item_12.slot == Slot::None, 'wrong item12 slot');
+
+        assert!(
+            verbose_bag.item_13.id == ItemId::Amulet,
+            "wrong item13 id. expected {:?}, actual {:?}",
+            ItemId::Amulet,
+            verbose_bag.item_13.id,
+        );
+        assert!(verbose_bag.item_13.xp == 130, "wrong item13 xp. expected 130, actual {:?}", verbose_bag.item_13.xp);
+        assert!(
+            verbose_bag.item_13.name == 'Amulet',
+            "wrong item13 name. expected {:?}, actual {:?}",
+            'Amulet',
+            verbose_bag.item_13.name,
+        );
+        assert(verbose_bag.item_13.tier == Tier::T1, 'wrong item13 tier');
+        assert(verbose_bag.item_13.item_type == Type::Necklace, 'wrong item13 type');
+        assert(verbose_bag.item_13.slot == Slot::Neck, 'wrong item13 slot');
+
+        assert!(
+            verbose_bag.item_14.id == ItemId::Pendant,
+            "wrong item14 id. expected {:?}, actual {:?}",
+            ItemId::Pendant,
+            verbose_bag.item_14.id,
+        );
+        assert!(verbose_bag.item_14.xp == 150, "wrong item14 xp. expected 150, actual {:?}", verbose_bag.item_14.xp);
+        assert!(
+            verbose_bag.item_14.name == 'Pendant',
+            "wrong item14 name. expected {:?}, actual {:?}",
+            'Pendant',
+            verbose_bag.item_14.name,
+        );
+        assert(verbose_bag.item_14.tier == Tier::T1, 'wrong item14 tier');
+        assert(verbose_bag.item_14.item_type == Type::Necklace, 'wrong item14 type');
+        assert(verbose_bag.item_14.slot == Slot::Neck, 'wrong item14 slot');
+
+        assert!(verbose_bag.item_15.id == 0, "wrong item15 id. expected {:?}, actual {:?}", 0, verbose_bag.item_15.id);
+        assert!(verbose_bag.item_15.xp == 0, "wrong item15 xp. expected 0, actual {:?}", verbose_bag.item_15.xp);
+        assert!(
+            verbose_bag.item_15.name == 0, "wrong item15 name. expected {:?}, actual {:?}", 0, verbose_bag.item_15.name,
+        );
+        assert(verbose_bag.item_15.tier == Tier::None, 'wrong item15 tier');
+        assert(verbose_bag.item_15.item_type == Type::None, 'wrong item15 type');
+        assert(verbose_bag.item_15.slot == Slot::None, 'wrong item15 slot');
     }
 }

--- a/contracts/src/models/adventurer/item.cairo
+++ b/contracts/src/models/adventurer/item.cairo
@@ -2,7 +2,9 @@
 
 use core::num::traits::Sqrt;
 use core::traits::DivRem;
-use death_mountain::constants::loot::ItemId;
+use death_mountain::constants::combat::CombatEnums::{Slot, Tier, Type};
+use death_mountain::constants::loot::{ImplItemNaming, ItemId};
+use death_mountain::models::loot::{ImplLoot};
 
 #[derive(Introspect, Drop, Copy, PartialEq, Serde)]
 // 21 bits in storage
@@ -13,6 +15,16 @@ pub struct Item {
     pub xp: u16,
 }
 
+// for clients and renderers
+#[derive(Introspect, Drop, Copy, PartialEq, Serde)]
+pub struct ItemVerbose {
+    pub name: felt252,
+    pub id: u8,
+    pub xp: u16,
+    pub tier: Tier,
+    pub item_type: Type,
+    pub slot: Slot,
+}
 
 #[generate_trait]
 pub impl ImplItem of IItemPrimitive {
@@ -104,6 +116,24 @@ pub impl ImplItem of IItemPrimitive {
     }
 }
 
+/// @notice Converts an Item to an ItemVerbose
+/// @param self the Item to convert
+/// @return ItemVerbose: the verbose Item
+impl ItemIntoItemVerbose of Into<Item, ItemVerbose> {
+    fn into(self: Item) -> ItemVerbose {
+        let item_stats = ImplLoot::get_item(self.id);
+        let name = ImplItemNaming::item_id_to_string(self.id);
+        ItemVerbose {
+            name,
+            id: self.id,
+            xp: self.xp,
+            tier: item_stats.tier,
+            item_type: item_stats.item_type,
+            slot: item_stats.slot,
+        }
+    }
+}
+
 const TWO_POW_7: u256 = 0x80;
 const TWO_POW_7_Z: NonZero<u256> = 0x80;
 const TWO_POW_9_Z: NonZero<u256> = 0x200;
@@ -117,9 +147,10 @@ pub const MAX_ITEM_XP: u16 = 400;
 // ---------------------------
 #[cfg(test)]
 mod tests {
+    use death_mountain::constants::combat::CombatEnums::{Slot, Tier, Type};
     use death_mountain::constants::loot::ItemId;
     use death_mountain::models::adventurer::item::{
-        IItemPrimitive, ImplItem, Item, MAX_PACKABLE_ITEM_ID, MAX_PACKABLE_XP,
+        IItemPrimitive, ImplItem, Item, ItemVerbose, MAX_ITEM_XP, MAX_PACKABLE_ITEM_ID, MAX_PACKABLE_XP,
     };
 
     #[test]
@@ -320,5 +351,239 @@ mod tests {
         item.xp = 65535;
         let greatness = item.get_greatness();
         assert(greatness == 20, 'greatness should be 20');
+    }
+
+    #[test]
+    #[available_gas(1000000)]
+    fn test_item_into_item_verbose_empty() {
+        let empty_item = Item { id: 0, xp: 0 };
+        let verbose_item: ItemVerbose = empty_item.into();
+
+        assert(verbose_item.id == 0, 'id should be 0');
+        assert(verbose_item.xp == 0, 'xp should be 0');
+        assert(verbose_item.name == 0, 'name should be 0');
+        assert(verbose_item.tier == Tier::None, 'tier should be None');
+        assert(verbose_item.item_type == Type::None, 'type should be None');
+        assert(verbose_item.slot == Slot::None, 'slot should be None');
+    }
+
+    #[test]
+    #[available_gas(1000000)]
+    fn test_item_into_item_verbose_weapon() {
+        // Test T1 weapon - Katana
+        let katana = Item { id: ItemId::Katana, xp: 100 };
+        let verbose_katana: ItemVerbose = katana.into();
+
+        assert(verbose_katana.id == ItemId::Katana, 'katana id mismatch');
+        assert(verbose_katana.xp == 100, 'katana xp mismatch');
+        assert(verbose_katana.name == 'Katana', 'katana name mismatch');
+        assert(verbose_katana.tier == Tier::T1, 'katana tier should be T1');
+        assert(verbose_katana.item_type == Type::Blade_or_Hide, 'katana type mismatch');
+        assert(verbose_katana.slot == Slot::Weapon, 'katana slot should be weapon');
+
+        // Test T5 weapon - Wand
+        let wand = Item { id: ItemId::Wand, xp: 50 };
+        let verbose_wand: ItemVerbose = wand.into();
+
+        assert(verbose_wand.id == ItemId::Wand, 'wand id mismatch');
+        assert(verbose_wand.xp == 50, 'wand xp mismatch');
+        assert(verbose_wand.name == 'Wand', 'wand name mismatch');
+        assert(verbose_wand.tier == Tier::T5, 'wand tier should be T5');
+        assert(verbose_wand.item_type == Type::Magic_or_Cloth, 'wand type mismatch');
+        assert(verbose_wand.slot == Slot::Weapon, 'wand slot should be weapon');
+    }
+
+    #[test]
+    #[available_gas(1000000)]
+    fn test_item_into_item_verbose_armor() {
+        // Test chest armor
+        let divine_robe = Item { id: ItemId::DivineRobe, xp: 200 };
+        let verbose_robe: ItemVerbose = divine_robe.into();
+
+        assert(verbose_robe.id == ItemId::DivineRobe, 'robe id mismatch');
+        assert(verbose_robe.xp == 200, 'robe xp mismatch');
+        assert(verbose_robe.name == 'Divine Robe', 'robe name mismatch');
+        assert(verbose_robe.tier == Tier::T1, 'robe tier should be T1');
+        assert(verbose_robe.item_type == Type::Magic_or_Cloth, 'robe type mismatch');
+        assert(verbose_robe.slot == Slot::Chest, 'robe slot should be chest');
+
+        // Test head armor
+        let crown = Item { id: ItemId::Crown, xp: 150 };
+        let verbose_crown: ItemVerbose = crown.into();
+
+        assert(verbose_crown.id == ItemId::Crown, 'crown id mismatch');
+        assert(verbose_crown.xp == 150, 'crown xp mismatch');
+        assert(verbose_crown.name == 'Crown', 'crown name mismatch');
+        assert(verbose_crown.tier == Tier::T1, 'crown tier should be T1');
+        assert(verbose_crown.item_type == Type::Magic_or_Cloth, 'crown type mismatch');
+        assert(verbose_crown.slot == Slot::Head, 'crown slot should be head');
+
+        // Test foot armor
+        let leather_boots = Item { id: ItemId::LeatherBoots, xp: 75 };
+        let verbose_boots: ItemVerbose = leather_boots.into();
+
+        assert(verbose_boots.id == ItemId::LeatherBoots, 'boots id mismatch');
+        assert(verbose_boots.xp == 75, 'boots xp mismatch');
+        assert(verbose_boots.name == 'Leather Boots', 'boots name mismatch');
+        assert(verbose_boots.tier == Tier::T5, 'boots tier should be T5');
+        assert(verbose_boots.item_type == Type::Blade_or_Hide, 'boots type mismatch');
+        assert(verbose_boots.slot == Slot::Foot, 'boots slot should be foot');
+    }
+
+    #[test]
+    #[available_gas(1000000)]
+    fn test_item_into_item_verbose_jewelry() {
+        // Test necklace
+        let amulet = Item { id: ItemId::Amulet, xp: 300 };
+        let verbose_amulet: ItemVerbose = amulet.into();
+
+        assert(verbose_amulet.id == ItemId::Amulet, 'amulet id mismatch');
+        assert(verbose_amulet.xp == 300, 'amulet xp mismatch');
+        assert(verbose_amulet.name == 'Amulet', 'amulet name mismatch');
+        assert(verbose_amulet.tier == Tier::T1, 'amulet tier should be T1');
+        assert(verbose_amulet.item_type == Type::Necklace, 'amulet type mismatch');
+        assert(verbose_amulet.slot == Slot::Neck, 'amulet slot should be neck');
+
+        // Test ring
+        let gold_ring = Item { id: ItemId::GoldRing, xp: 250 };
+        let verbose_ring: ItemVerbose = gold_ring.into();
+
+        assert(verbose_ring.id == ItemId::GoldRing, 'ring id mismatch');
+        assert(verbose_ring.xp == 250, 'ring xp mismatch');
+        assert(verbose_ring.name == 'Gold Ring', 'ring name mismatch');
+        assert(verbose_ring.tier == Tier::T1, 'ring tier should be T1');
+        assert(verbose_ring.item_type == Type::Ring, 'ring type mismatch');
+        assert(verbose_ring.slot == Slot::Ring, 'ring slot should be ring');
+    }
+
+    #[test]
+    #[available_gas(1000000)]
+    fn test_item_into_item_verbose_all_tiers() {
+        // T1 item
+        let t1_item = Item { id: ItemId::GhostWand, xp: 10 };
+        let verbose_t1: ItemVerbose = t1_item.into();
+        assert(verbose_t1.tier == Tier::T1, 'T1 tier mismatch');
+        assert(verbose_t1.name == 'Ghost Wand', 'T1 name mismatch');
+
+        // T2 item
+        let t2_item = Item { id: ItemId::SilkRobe, xp: 20 };
+        let verbose_t2: ItemVerbose = t2_item.into();
+        assert(verbose_t2.tier == Tier::T2, 'T2 tier mismatch');
+        assert(verbose_t2.name == 'Silk Robe', 'T2 name mismatch');
+
+        // T3 item
+        let t3_item = Item { id: ItemId::BronzeRing, xp: 30 };
+        let verbose_t3: ItemVerbose = t3_item.into();
+        assert(verbose_t3.tier == Tier::T3, 'T3 tier mismatch');
+        assert(verbose_t3.name == 'Bronze Ring', 'T3 name mismatch');
+
+        // T4 item
+        let t4_item = Item { id: ItemId::LinenHood, xp: 40 };
+        let verbose_t4: ItemVerbose = t4_item.into();
+        assert(verbose_t4.tier == Tier::T4, 'T4 tier mismatch');
+        assert(verbose_t4.name == 'Linen Hood', 'T4 name mismatch');
+
+        // T5 item
+        let t5_item = Item { id: ItemId::Shoes, xp: 50 };
+        let verbose_t5: ItemVerbose = t5_item.into();
+        assert(verbose_t5.tier == Tier::T5, 'T5 tier mismatch');
+        assert(verbose_t5.name == 'Shoes', 'T5 name mismatch');
+    }
+
+    #[test]
+    #[available_gas(1000000)]
+    fn test_item_into_item_verbose_xp_values() {
+        // Test with 0 XP
+        let zero_xp = Item { id: ItemId::Katana, xp: 0 };
+        let verbose_zero: ItemVerbose = zero_xp.into();
+        assert(verbose_zero.xp == 0, 'zero xp mismatch');
+
+        // Test with max item XP
+        let max_xp = Item { id: ItemId::DivineRobe, xp: MAX_ITEM_XP };
+        let verbose_max: ItemVerbose = max_xp.into();
+        assert(verbose_max.xp == MAX_ITEM_XP, 'max xp mismatch');
+
+        // Test with max packable XP
+        let max_pack_xp = Item { id: ItemId::Crown, xp: MAX_PACKABLE_XP };
+        let verbose_max_pack: ItemVerbose = max_pack_xp.into();
+        assert(verbose_max_pack.xp == MAX_PACKABLE_XP, 'max packable xp mismatch');
+
+        // Test various XP values preserve correctly
+        let mid_xp = Item { id: ItemId::Amulet, xp: 255 };
+        let verbose_mid: ItemVerbose = mid_xp.into();
+        assert(verbose_mid.xp == 255, 'mid xp mismatch');
+    }
+
+    #[test]
+    #[available_gas(1000000)]
+    fn test_item_into_item_verbose_all_slots() {
+        // Weapon slot
+        let weapon = Item { id: ItemId::Warhammer, xp: 10 };
+        let verbose_weapon: ItemVerbose = weapon.into();
+        assert(verbose_weapon.slot == Slot::Weapon, 'weapon slot mismatch');
+
+        // Chest slot
+        let chest = Item { id: ItemId::HolyChestplate, xp: 20 };
+        let verbose_chest: ItemVerbose = chest.into();
+        assert(verbose_chest.slot == Slot::Chest, 'chest slot mismatch');
+
+        // Head slot
+        let head = Item { id: ItemId::DemonCrown, xp: 30 };
+        let verbose_head: ItemVerbose = head.into();
+        assert(verbose_head.slot == Slot::Head, 'head slot mismatch');
+
+        // Waist slot
+        let waist = Item { id: ItemId::DemonhideBelt, xp: 40 };
+        let verbose_waist: ItemVerbose = waist.into();
+        assert(verbose_waist.slot == Slot::Waist, 'waist slot mismatch');
+
+        // Foot slot
+        let foot = Item { id: ItemId::DivineSlippers, xp: 50 };
+        let verbose_foot: ItemVerbose = foot.into();
+        assert(verbose_foot.slot == Slot::Foot, 'foot slot mismatch');
+
+        // Hand slot
+        let hand = Item { id: ItemId::DivineGloves, xp: 60 };
+        let verbose_hand: ItemVerbose = hand.into();
+        assert(verbose_hand.slot == Slot::Hand, 'hand slot mismatch');
+
+        // Neck slot
+        let neck = Item { id: ItemId::Pendant, xp: 70 };
+        let verbose_neck: ItemVerbose = neck.into();
+        assert(verbose_neck.slot == Slot::Neck, 'neck slot mismatch');
+
+        // Ring slot
+        let ring = Item { id: ItemId::PlatinumRing, xp: 80 };
+        let verbose_ring: ItemVerbose = ring.into();
+        assert(verbose_ring.slot == Slot::Ring, 'ring slot mismatch');
+    }
+
+    #[test]
+    #[available_gas(1000000)]
+    fn test_item_into_item_verbose_all_types() {
+        // Magic or Cloth type
+        let magic_item = Item { id: ItemId::Grimoire, xp: 100 };
+        let verbose_magic: ItemVerbose = magic_item.into();
+        assert(verbose_magic.item_type == Type::Magic_or_Cloth, 'magic type mismatch');
+
+        // Blade or Hide type
+        let blade_item = Item { id: ItemId::Falchion, xp: 200 };
+        let verbose_blade: ItemVerbose = blade_item.into();
+        assert(verbose_blade.item_type == Type::Blade_or_Hide, 'blade type mismatch');
+
+        // Bludgeon or Metal type
+        let bludgeon_item = Item { id: ItemId::Quarterstaff, xp: 300 };
+        let verbose_bludgeon: ItemVerbose = bludgeon_item.into();
+        assert(verbose_bludgeon.item_type == Type::Bludgeon_or_Metal, 'bludgeon type mismatch');
+
+        // Necklace type
+        let necklace_item = Item { id: ItemId::Necklace, xp: 400 };
+        let verbose_necklace: ItemVerbose = necklace_item.into();
+        assert(verbose_necklace.item_type == Type::Necklace, 'necklace type mismatch');
+
+        // Ring type
+        let ring_item = Item { id: ItemId::SilverRing, xp: 500 };
+        let verbose_ring: ItemVerbose = ring_item.into();
+        assert(verbose_ring.item_type == Type::Ring, 'ring type mismatch');
     }
 }

--- a/new_issues/item-special-storage-refactor.md
+++ b/new_issues/item-special-storage-refactor.md
@@ -1,0 +1,109 @@
+# Feature: Individual Item Special Storage
+
+## Overview
+
+Refactor the item specials storage system to provide each item with its own dedicated storage instead of all items sharing a single seed. This will enable persistent, unique special attributes for each item instance, improving randomness variety and reducing computational overhead from repeated calculations.
+
+## Background
+
+Currently, the Death Mountain game uses a shared storage pattern for item specials where:
+- Each adventurer has a single `item_specials_seed` (16 bits) stored in the Adventurer struct
+- Item specials are calculated on-demand by combining this shared seed with item-specific entropy
+- This requires recalculation every time specials are needed (combat, stats, display)
+- All items for an adventurer share the same base seed, limiting randomness variety
+
+This approach has served well for initial implementation but presents limitations as the game scales:
+- Gas costs from repeated calculations during combat and stat applications
+- Limited entropy space due to single seed constraint
+- No ability to persist unique or evolving special attributes per item
+- Inability to support future features like upgradeable or tradeable item specials
+
+## Requirements
+
+### Functional Requirements
+
+1. **Individual Storage**: Each item instance should have its own persistent storage for special powers
+2. **Backward Compatibility**: Existing adventurers with shared seeds must continue to function
+3. **Migration Path**: Provide a mechanism to migrate from shared seed to individual storage
+4. **Query Efficiency**: Support efficient batch queries for multiple item specials
+5. **Storage Efficiency**: Use packed storage patterns similar to existing models (AdventurerPacked, BagPacked)
+
+### Performance Requirements
+
+- Reduce gas costs by eliminating repeated special calculations
+- Support efficient bulk operations for querying all item specials for an adventurer
+- Maintain or improve current response times for item special retrieval
+
+### Data Model Requirements
+
+- Store specials using a Map-like structure with composite keys (e.g., `(adventurer_id, item_id)`)
+- Preserve the existing SpecialPowers structure (special1, special2, special3)
+- Support the current unlock mechanics (greatness 15 for suffix, 20 for prefixes)
+
+## Technical Context
+
+### Current Implementation
+- **Adventurer Model**: `contracts/src/models/adventurer/adventurer.cairo` - Contains `item_specials_seed`
+- **Loot System**: `contracts/src/models/loot.cairo` - `get_specials()` calculation logic
+- **Combat System**: `contracts/src/models/combat.cairo` - SpecialPowers struct definition
+- **Game System**: `contracts/src/systems/game/contracts.cairo` - Uses specials in combat and stats
+
+### Existing Storage Patterns
+- **Simple Models**: `ScoreObjective` with single key
+- **Composite Key Models**: `CollectableEntity` with multiple keys
+- **Packed Models**: `AdventurerPacked`, `BagPacked` for efficient storage
+- **Relationship Models**: `DroppedItem` linking entities
+
+### Key Interfaces
+- `ILoot::get_specials()` - Current interface for calculating specials
+- Special unlock constants: `SUFFIX_UNLOCK_GREATNESS = 15`, `PREFIXES_UNLOCK_GREATNESS = 20`
+
+## Acceptance Criteria
+
+- [ ] New Dojo model created for individual item special storage
+- [ ] Storage uses composite key structure (adventurer_id + item identifier)
+- [ ] Existing shared seed functionality remains for backward compatibility
+- [ ] Migration mechanism allows transitioning from shared to individual storage
+- [ ] Game system updated to read from individual storage when available
+- [ ] Batch query support for retrieving all specials for an adventurer
+- [ ] Gas costs reduced compared to current repeated calculations
+- [ ] All existing tests pass with new implementation
+- [ ] New tests verify individual storage functionality
+- [ ] Documentation updated to reflect new storage pattern
+
+## Testing Requirements
+
+### Unit Tests
+- Test individual special storage and retrieval
+- Verify backward compatibility with shared seed
+- Test migration from shared to individual storage
+- Validate batch query operations
+
+### Integration Tests
+- Combat calculations use correct specials from individual storage
+- Stat boosts apply correctly with new storage
+- Special unlock mechanics work as expected
+- Performance benchmarks show improvement
+
+### Edge Cases to Test
+- Adventurer with no specials unlocked
+- Adventurer with partial migration (some items migrated, others not)
+- Maximum number of items with specials
+- Concurrent access patterns
+
+## Questions for Implementation
+
+1. Should we use item_id or item_slot as part of the composite key?
+2. What's the preferred migration strategy - lazy (on-demand) or batch?
+3. Should we maintain the current entropy-based generation for initial values?
+4. Do we need versioning to support future special mechanics changes?
+5. Should special values be mutable after initial generation?
+
+## Future Considerations
+
+This refactor opens possibilities for:
+- Upgradeable item specials through gameplay
+- Trading items with persistent special attributes
+- More complex special mechanics (evolving specials, combinations)
+- Reduced gas costs for combat-heavy gameplay
+- Better support for item NFT metadata with unique attributes


### PR DESCRIPTION
## Summary

This PR introduces the **AdventurerVerbose** model, an improvement that simplifies onchain rendering of adventurers. Previously, renderers had to make multiple lookups to get complete adventurer information - fetching the base Adventurer data, then manually looking up each item's details (name, slot, tier, etc.). This created complexity and inefficiency for anyone building UIs or integrations.

### Key Innovation: AdventurerVerbose

The new `AdventurerVerbose` model provides a single endpoint that returns everything renderers need:
- Complete adventurer stats and metadata
- Full item details including names, slots, and tiers
- Equipment information with all relevant properties
- Bag contents with complete item specifications

This eliminates the need for multiple contract calls and manual data assembly, making it significantly easier to build rich UIs and integrations for Death Mountain.

## Technical Implementation

### Models Enhanced (4 files, +1,436 lines)
- `adventurer.cairo`: Added AdventurerVerbose struct with comprehensive data
- `bag.cairo`: Enhanced with BagVerbose for complete item details
- `equipment.cairo`: Implemented EquipmentVerbose with full item properties
- `item.cairo`: Added ItemVerbose with name, slot, and tier information

### Systems Updated (2 files, +641 lines)
- `adventurer/contracts.cairo`: New get_adventurer_verbose endpoint
- `game/contracts.cairo`: Integration with verbose models

## Benefits for Developers

1. **Single Contract Call**: Get all adventurer data in one request instead of multiple lookups
2. **Simplified Rendering**: No need to manually resolve item IDs to names and properties
3. **Reduced Complexity**: Frontend code becomes cleaner and more maintainable
4. **Better Performance**: Fewer RPC calls mean faster UI updates

## Example Usage

Previously:
```cairo
// Get adventurer
let adventurer = get_adventurer(id);
// Then lookup each item individually
let weapon = get_item(adventurer.weapon_id);
let chest = get_item(adventurer.chest_id);
// ... repeat for all equipment
```

Now:
```cairo
// Get everything in one call
let adventurer_verbose = get_adventurer_verbose(id);
// All item details are included
// adventurer_verbose.equipment.weapon.name
// adventurer_verbose.equipment.weapon.tier
// etc.
```

## Testing

- [x] All existing tests pass
- [x] Code compiles successfully with `sozo build`
- [x] New verbose endpoints tested
- [x] No breaking changes to existing APIs

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced verbose representations for adventurers, equipment, bags, and items, providing detailed metadata such as names, tiers, types, and slots for improved client and renderer support.
  * Added a new method to retrieve comprehensive adventurer details in a single call.

* **Tests**
  * Added extensive tests to validate the correctness of verbose conversions for items, equipment, and bags, as well as the new verbose adventurer retrieval.

* **Documentation**
  * Added a detailed feature specification outlining a planned refactor for item special storage, including requirements, performance goals, and migration strategy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->