### PR TITLE
Add Sepolia Denshokan infra

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,7 @@ contracts/deploy
 contracts/.DS_Store
 .DS_Store
 veo-client/tsconfig.tsbuildinfo
+.env
+.env.local
+*.env.bak
+argent_account_*.json

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-dojo 1.6.0-alpha.2
+dojo 1.6.0
 scarb 2.10.1

--- a/client/manifest_sepolia.json
+++ b/client/manifest_sepolia.json
@@ -1,8 +1,8 @@
 {
   "world": {
-    "class_hash": "0x4c60dc46a8ca8bb47675b7b914053cef769afbf0e340523187336b72bd71d1f",
-    "address": "0x5246cbbe2bef7fd190adbf05e47bee876ab2ab0e272c3346e0e760cd26adaa7",
-    "seed": "test_ls_0_4",
+    "class_hash": "0x685ed02eefa98fe7e208aa295042e9bbad8029b0d3d6f0ba2b32546efe0a1f9",
+    "address": "0x38f6eb0186dfd1e072fa3b289b88e1c67b0baf1bd76cc6987f4a93258c69c4d",
+    "seed": "DNC",
     "name": "Provable Games",
     "entrypoints": [
       "uuid",
@@ -1328,8 +1328,8 @@
   },
   "contracts": [
     {
-      "address": "0x36a767f7e7f4be4598b81cb61b67b9545e49edd8f4fcb572096ed4b9d0450d3",
-      "class_hash": "0x113d778b7dd3c32f2f6d45ac0dc2c79ed39b29656eef91b92696f27fd3a6b8c",
+      "address": "0x7cb86dc3a492d4e2db3afee800d9481ab862c67fc15f98bab4817de8370f2f7",
+      "class_hash": "0x5acc9993f40b542e4fc167a5ace9047dc2776fc36f1a07b966e0142388a0edb",
       "abi": [
         {
           "type": "impl",
@@ -1384,11 +1384,25 @@
         {
           "type": "impl",
           "name": "AdventurerSystemsImpl",
-          "interface_name": "lootsurvivor::systems::adventurer::contracts::IAdventurerSystems"
+          "interface_name": "death_mountain::systems::adventurer::contracts::IAdventurerSystems"
         },
         {
           "type": "struct",
-          "name": "lootsurvivor::models::adventurer::stats::Stats",
+          "name": "death_mountain::models::adventurer::item::Item",
+          "members": [
+            {
+              "name": "id",
+              "type": "core::integer::u8"
+            },
+            {
+              "name": "xp",
+              "type": "core::integer::u16"
+            }
+          ]
+        },
+        {
+          "type": "struct",
+          "name": "death_mountain::models::adventurer::stats::Stats",
           "members": [
             {
               "name": "strength",
@@ -1422,59 +1436,45 @@
         },
         {
           "type": "struct",
-          "name": "lootsurvivor::models::adventurer::item::Item",
-          "members": [
-            {
-              "name": "id",
-              "type": "core::integer::u8"
-            },
-            {
-              "name": "xp",
-              "type": "core::integer::u16"
-            }
-          ]
-        },
-        {
-          "type": "struct",
-          "name": "lootsurvivor::models::adventurer::equipment::Equipment",
+          "name": "death_mountain::models::adventurer::equipment::Equipment",
           "members": [
             {
               "name": "weapon",
-              "type": "lootsurvivor::models::adventurer::item::Item"
+              "type": "death_mountain::models::adventurer::item::Item"
             },
             {
               "name": "chest",
-              "type": "lootsurvivor::models::adventurer::item::Item"
+              "type": "death_mountain::models::adventurer::item::Item"
             },
             {
               "name": "head",
-              "type": "lootsurvivor::models::adventurer::item::Item"
+              "type": "death_mountain::models::adventurer::item::Item"
             },
             {
               "name": "waist",
-              "type": "lootsurvivor::models::adventurer::item::Item"
+              "type": "death_mountain::models::adventurer::item::Item"
             },
             {
               "name": "foot",
-              "type": "lootsurvivor::models::adventurer::item::Item"
+              "type": "death_mountain::models::adventurer::item::Item"
             },
             {
               "name": "hand",
-              "type": "lootsurvivor::models::adventurer::item::Item"
+              "type": "death_mountain::models::adventurer::item::Item"
             },
             {
               "name": "neck",
-              "type": "lootsurvivor::models::adventurer::item::Item"
+              "type": "death_mountain::models::adventurer::item::Item"
             },
             {
               "name": "ring",
-              "type": "lootsurvivor::models::adventurer::item::Item"
+              "type": "death_mountain::models::adventurer::item::Item"
             }
           ]
         },
         {
           "type": "struct",
-          "name": "lootsurvivor::models::adventurer::adventurer::Adventurer",
+          "name": "death_mountain::models::adventurer::adventurer::Adventurer",
           "members": [
             {
               "name": "health",
@@ -1498,11 +1498,11 @@
             },
             {
               "name": "stats",
-              "type": "lootsurvivor::models::adventurer::stats::Stats"
+              "type": "death_mountain::models::adventurer::stats::Stats"
             },
             {
               "name": "equipment",
-              "type": "lootsurvivor::models::adventurer::equipment::Equipment"
+              "type": "death_mountain::models::adventurer::equipment::Equipment"
             },
             {
               "name": "item_specials_seed",
@@ -1530,67 +1530,67 @@
         },
         {
           "type": "struct",
-          "name": "lootsurvivor::models::adventurer::bag::Bag",
+          "name": "death_mountain::models::adventurer::bag::Bag",
           "members": [
             {
               "name": "item_1",
-              "type": "lootsurvivor::models::adventurer::item::Item"
+              "type": "death_mountain::models::adventurer::item::Item"
             },
             {
               "name": "item_2",
-              "type": "lootsurvivor::models::adventurer::item::Item"
+              "type": "death_mountain::models::adventurer::item::Item"
             },
             {
               "name": "item_3",
-              "type": "lootsurvivor::models::adventurer::item::Item"
+              "type": "death_mountain::models::adventurer::item::Item"
             },
             {
               "name": "item_4",
-              "type": "lootsurvivor::models::adventurer::item::Item"
+              "type": "death_mountain::models::adventurer::item::Item"
             },
             {
               "name": "item_5",
-              "type": "lootsurvivor::models::adventurer::item::Item"
+              "type": "death_mountain::models::adventurer::item::Item"
             },
             {
               "name": "item_6",
-              "type": "lootsurvivor::models::adventurer::item::Item"
+              "type": "death_mountain::models::adventurer::item::Item"
             },
             {
               "name": "item_7",
-              "type": "lootsurvivor::models::adventurer::item::Item"
+              "type": "death_mountain::models::adventurer::item::Item"
             },
             {
               "name": "item_8",
-              "type": "lootsurvivor::models::adventurer::item::Item"
+              "type": "death_mountain::models::adventurer::item::Item"
             },
             {
               "name": "item_9",
-              "type": "lootsurvivor::models::adventurer::item::Item"
+              "type": "death_mountain::models::adventurer::item::Item"
             },
             {
               "name": "item_10",
-              "type": "lootsurvivor::models::adventurer::item::Item"
+              "type": "death_mountain::models::adventurer::item::Item"
             },
             {
               "name": "item_11",
-              "type": "lootsurvivor::models::adventurer::item::Item"
+              "type": "death_mountain::models::adventurer::item::Item"
             },
             {
               "name": "item_12",
-              "type": "lootsurvivor::models::adventurer::item::Item"
+              "type": "death_mountain::models::adventurer::item::Item"
             },
             {
               "name": "item_13",
-              "type": "lootsurvivor::models::adventurer::item::Item"
+              "type": "death_mountain::models::adventurer::item::Item"
             },
             {
               "name": "item_14",
-              "type": "lootsurvivor::models::adventurer::item::Item"
+              "type": "death_mountain::models::adventurer::item::Item"
             },
             {
               "name": "item_15",
-              "type": "lootsurvivor::models::adventurer::item::Item"
+              "type": "death_mountain::models::adventurer::item::Item"
             },
             {
               "name": "mutated",
@@ -1600,7 +1600,315 @@
         },
         {
           "type": "enum",
-          "name": "lootsurvivor::constants::discovery::DiscoveryEnums::DiscoveryType",
+          "name": "death_mountain::constants::combat::CombatEnums::Tier",
+          "variants": [
+            {
+              "name": "None",
+              "type": "()"
+            },
+            {
+              "name": "T1",
+              "type": "()"
+            },
+            {
+              "name": "T2",
+              "type": "()"
+            },
+            {
+              "name": "T3",
+              "type": "()"
+            },
+            {
+              "name": "T4",
+              "type": "()"
+            },
+            {
+              "name": "T5",
+              "type": "()"
+            }
+          ]
+        },
+        {
+          "type": "enum",
+          "name": "death_mountain::constants::combat::CombatEnums::Type",
+          "variants": [
+            {
+              "name": "None",
+              "type": "()"
+            },
+            {
+              "name": "Magic_or_Cloth",
+              "type": "()"
+            },
+            {
+              "name": "Blade_or_Hide",
+              "type": "()"
+            },
+            {
+              "name": "Bludgeon_or_Metal",
+              "type": "()"
+            },
+            {
+              "name": "Necklace",
+              "type": "()"
+            },
+            {
+              "name": "Ring",
+              "type": "()"
+            }
+          ]
+        },
+        {
+          "type": "enum",
+          "name": "death_mountain::constants::combat::CombatEnums::Slot",
+          "variants": [
+            {
+              "name": "None",
+              "type": "()"
+            },
+            {
+              "name": "Weapon",
+              "type": "()"
+            },
+            {
+              "name": "Chest",
+              "type": "()"
+            },
+            {
+              "name": "Head",
+              "type": "()"
+            },
+            {
+              "name": "Waist",
+              "type": "()"
+            },
+            {
+              "name": "Foot",
+              "type": "()"
+            },
+            {
+              "name": "Hand",
+              "type": "()"
+            },
+            {
+              "name": "Neck",
+              "type": "()"
+            },
+            {
+              "name": "Ring",
+              "type": "()"
+            }
+          ]
+        },
+        {
+          "type": "struct",
+          "name": "death_mountain::models::adventurer::item::ItemVerbose",
+          "members": [
+            {
+              "name": "name",
+              "type": "core::felt252"
+            },
+            {
+              "name": "id",
+              "type": "core::integer::u8"
+            },
+            {
+              "name": "xp",
+              "type": "core::integer::u16"
+            },
+            {
+              "name": "tier",
+              "type": "death_mountain::constants::combat::CombatEnums::Tier"
+            },
+            {
+              "name": "item_type",
+              "type": "death_mountain::constants::combat::CombatEnums::Type"
+            },
+            {
+              "name": "slot",
+              "type": "death_mountain::constants::combat::CombatEnums::Slot"
+            }
+          ]
+        },
+        {
+          "type": "struct",
+          "name": "death_mountain::models::adventurer::equipment::EquipmentVerbose",
+          "members": [
+            {
+              "name": "weapon",
+              "type": "death_mountain::models::adventurer::item::ItemVerbose"
+            },
+            {
+              "name": "chest",
+              "type": "death_mountain::models::adventurer::item::ItemVerbose"
+            },
+            {
+              "name": "head",
+              "type": "death_mountain::models::adventurer::item::ItemVerbose"
+            },
+            {
+              "name": "waist",
+              "type": "death_mountain::models::adventurer::item::ItemVerbose"
+            },
+            {
+              "name": "foot",
+              "type": "death_mountain::models::adventurer::item::ItemVerbose"
+            },
+            {
+              "name": "hand",
+              "type": "death_mountain::models::adventurer::item::ItemVerbose"
+            },
+            {
+              "name": "neck",
+              "type": "death_mountain::models::adventurer::item::ItemVerbose"
+            },
+            {
+              "name": "ring",
+              "type": "death_mountain::models::adventurer::item::ItemVerbose"
+            }
+          ]
+        },
+        {
+          "type": "struct",
+          "name": "death_mountain::models::adventurer::bag::BagVerbose",
+          "members": [
+            {
+              "name": "item_1",
+              "type": "death_mountain::models::adventurer::item::ItemVerbose"
+            },
+            {
+              "name": "item_2",
+              "type": "death_mountain::models::adventurer::item::ItemVerbose"
+            },
+            {
+              "name": "item_3",
+              "type": "death_mountain::models::adventurer::item::ItemVerbose"
+            },
+            {
+              "name": "item_4",
+              "type": "death_mountain::models::adventurer::item::ItemVerbose"
+            },
+            {
+              "name": "item_5",
+              "type": "death_mountain::models::adventurer::item::ItemVerbose"
+            },
+            {
+              "name": "item_6",
+              "type": "death_mountain::models::adventurer::item::ItemVerbose"
+            },
+            {
+              "name": "item_7",
+              "type": "death_mountain::models::adventurer::item::ItemVerbose"
+            },
+            {
+              "name": "item_8",
+              "type": "death_mountain::models::adventurer::item::ItemVerbose"
+            },
+            {
+              "name": "item_9",
+              "type": "death_mountain::models::adventurer::item::ItemVerbose"
+            },
+            {
+              "name": "item_10",
+              "type": "death_mountain::models::adventurer::item::ItemVerbose"
+            },
+            {
+              "name": "item_11",
+              "type": "death_mountain::models::adventurer::item::ItemVerbose"
+            },
+            {
+              "name": "item_12",
+              "type": "death_mountain::models::adventurer::item::ItemVerbose"
+            },
+            {
+              "name": "item_13",
+              "type": "death_mountain::models::adventurer::item::ItemVerbose"
+            },
+            {
+              "name": "item_14",
+              "type": "death_mountain::models::adventurer::item::ItemVerbose"
+            },
+            {
+              "name": "item_15",
+              "type": "death_mountain::models::adventurer::item::ItemVerbose"
+            }
+          ]
+        },
+        {
+          "type": "struct",
+          "name": "death_mountain::models::adventurer::adventurer::AdventurerVerbose",
+          "members": [
+            {
+              "name": "name",
+              "type": "core::byte_array::ByteArray"
+            },
+            {
+              "name": "health",
+              "type": "core::integer::u16"
+            },
+            {
+              "name": "xp",
+              "type": "core::integer::u16"
+            },
+            {
+              "name": "level",
+              "type": "core::integer::u8"
+            },
+            {
+              "name": "gold",
+              "type": "core::integer::u16"
+            },
+            {
+              "name": "beast_health",
+              "type": "core::integer::u16"
+            },
+            {
+              "name": "stat_upgrades_available",
+              "type": "core::integer::u8"
+            },
+            {
+              "name": "stats",
+              "type": "death_mountain::models::adventurer::stats::Stats"
+            },
+            {
+              "name": "equipment",
+              "type": "death_mountain::models::adventurer::equipment::EquipmentVerbose"
+            },
+            {
+              "name": "item_specials_seed",
+              "type": "core::integer::u16"
+            },
+            {
+              "name": "action_count",
+              "type": "core::integer::u16"
+            },
+            {
+              "name": "bag",
+              "type": "death_mountain::models::adventurer::bag::BagVerbose"
+            }
+          ]
+        },
+        {
+          "type": "struct",
+          "name": "death_mountain::models::game::AdventurerEntropy",
+          "members": [
+            {
+              "name": "adventurer_id",
+              "type": "core::integer::u64"
+            },
+            {
+              "name": "market_seed",
+              "type": "core::integer::u64"
+            },
+            {
+              "name": "beast_seed",
+              "type": "core::integer::u64"
+            }
+          ]
+        },
+        {
+          "type": "enum",
+          "name": "death_mountain::constants::discovery::DiscoveryEnums::DiscoveryType",
           "variants": [
             {
               "name": "Gold",
@@ -1618,8 +1926,24 @@
         },
         {
           "type": "interface",
-          "name": "lootsurvivor::systems::adventurer::contracts::IAdventurerSystems",
+          "name": "death_mountain::systems::adventurer::contracts::IAdventurerSystems",
           "items": [
+            {
+              "type": "function",
+              "name": "record_item_drop",
+              "inputs": [
+                {
+                  "name": "adventurer_id",
+                  "type": "core::integer::u64"
+                },
+                {
+                  "name": "item",
+                  "type": "death_mountain::models::adventurer::item::Item"
+                }
+              ],
+              "outputs": [],
+              "state_mutability": "external"
+            },
             {
               "type": "function",
               "name": "generate_starting_stats",
@@ -1631,7 +1955,7 @@
               ],
               "outputs": [
                 {
-                  "type": "lootsurvivor::models::adventurer::stats::Stats"
+                  "type": "death_mountain::models::adventurer::stats::Stats"
                 }
               ],
               "state_mutability": "view"
@@ -1647,7 +1971,7 @@
               ],
               "outputs": [
                 {
-                  "type": "(lootsurvivor::models::adventurer::adventurer::Adventurer, lootsurvivor::models::adventurer::bag::Bag)"
+                  "type": "(death_mountain::models::adventurer::adventurer::Adventurer, death_mountain::models::adventurer::bag::Bag)"
                 }
               ],
               "state_mutability": "view"
@@ -1663,7 +1987,71 @@
               ],
               "outputs": [
                 {
-                  "type": "lootsurvivor::models::adventurer::adventurer::Adventurer"
+                  "type": "death_mountain::models::adventurer::adventurer::Adventurer"
+                }
+              ],
+              "state_mutability": "view"
+            },
+            {
+              "type": "function",
+              "name": "get_adventurer_level",
+              "inputs": [
+                {
+                  "name": "adventurer_id",
+                  "type": "core::integer::u64"
+                }
+              ],
+              "outputs": [
+                {
+                  "type": "core::integer::u8"
+                }
+              ],
+              "state_mutability": "view"
+            },
+            {
+              "type": "function",
+              "name": "get_adventurer_dungeon",
+              "inputs": [
+                {
+                  "name": "adventurer_id",
+                  "type": "core::integer::u64"
+                }
+              ],
+              "outputs": [
+                {
+                  "type": "core::starknet::contract_address::ContractAddress"
+                }
+              ],
+              "state_mutability": "view"
+            },
+            {
+              "type": "function",
+              "name": "get_adventurer_verbose",
+              "inputs": [
+                {
+                  "name": "adventurer_id",
+                  "type": "core::integer::u64"
+                }
+              ],
+              "outputs": [
+                {
+                  "type": "death_mountain::models::adventurer::adventurer::AdventurerVerbose"
+                }
+              ],
+              "state_mutability": "view"
+            },
+            {
+              "type": "function",
+              "name": "get_adventurer_entropy",
+              "inputs": [
+                {
+                  "name": "adventurer_id",
+                  "type": "core::integer::u64"
+                }
+              ],
+              "outputs": [
+                {
+                  "type": "death_mountain::models::game::AdventurerEntropy"
                 }
               ],
               "state_mutability": "view"
@@ -1679,7 +2067,7 @@
               ],
               "outputs": [
                 {
-                  "type": "lootsurvivor::models::adventurer::bag::Bag"
+                  "type": "death_mountain::models::adventurer::bag::Bag"
                 }
               ],
               "state_mutability": "view"
@@ -1695,7 +2083,7 @@
               ],
               "outputs": [
                 {
-                  "type": "core::felt252"
+                  "type": "core::byte_array::ByteArray"
                 }
               ],
               "state_mutability": "view"
@@ -1706,16 +2094,16 @@
               "inputs": [
                 {
                   "name": "adventurer",
-                  "type": "lootsurvivor::models::adventurer::adventurer::Adventurer"
+                  "type": "death_mountain::models::adventurer::adventurer::Adventurer"
                 },
                 {
                   "name": "bag",
-                  "type": "lootsurvivor::models::adventurer::bag::Bag"
+                  "type": "death_mountain::models::adventurer::bag::Bag"
                 }
               ],
               "outputs": [
                 {
-                  "type": "lootsurvivor::models::adventurer::adventurer::Adventurer"
+                  "type": "death_mountain::models::adventurer::adventurer::Adventurer"
                 }
               ],
               "state_mutability": "view"
@@ -1726,7 +2114,7 @@
               "inputs": [
                 {
                   "name": "adventurer",
-                  "type": "lootsurvivor::models::adventurer::adventurer::Adventurer"
+                  "type": "death_mountain::models::adventurer::adventurer::Adventurer"
                 }
               ],
               "outputs": [
@@ -1759,7 +2147,7 @@
               ],
               "outputs": [
                 {
-                  "type": "lootsurvivor::constants::discovery::DiscoveryEnums::DiscoveryType"
+                  "type": "death_mountain::constants::discovery::DiscoveryEnums::DiscoveryType"
                 }
               ],
               "state_mutability": "view"
@@ -1770,7 +2158,7 @@
               "inputs": [
                 {
                   "name": "bag",
-                  "type": "lootsurvivor::models::adventurer::bag::Bag"
+                  "type": "death_mountain::models::adventurer::bag::Bag"
                 }
               ],
               "outputs": [
@@ -1782,40 +2170,20 @@
             },
             {
               "type": "function",
-              "name": "get_bag_item",
-              "inputs": [
-                {
-                  "name": "bag",
-                  "type": "lootsurvivor::models::adventurer::bag::Bag"
-                },
-                {
-                  "name": "item_id",
-                  "type": "core::integer::u8"
-                }
-              ],
-              "outputs": [
-                {
-                  "type": "lootsurvivor::models::adventurer::item::Item"
-                }
-              ],
-              "state_mutability": "view"
-            },
-            {
-              "type": "function",
               "name": "add_item_to_bag",
               "inputs": [
                 {
                   "name": "bag",
-                  "type": "lootsurvivor::models::adventurer::bag::Bag"
+                  "type": "death_mountain::models::adventurer::bag::Bag"
                 },
                 {
                   "name": "item",
-                  "type": "lootsurvivor::models::adventurer::item::Item"
+                  "type": "death_mountain::models::adventurer::item::Item"
                 }
               ],
               "outputs": [
                 {
-                  "type": "lootsurvivor::models::adventurer::bag::Bag"
+                  "type": "death_mountain::models::adventurer::bag::Bag"
                 }
               ],
               "state_mutability": "view"
@@ -1826,7 +2194,7 @@
               "inputs": [
                 {
                   "name": "bag",
-                  "type": "lootsurvivor::models::adventurer::bag::Bag"
+                  "type": "death_mountain::models::adventurer::bag::Bag"
                 },
                 {
                   "name": "item_id",
@@ -1835,7 +2203,7 @@
               ],
               "outputs": [
                 {
-                  "type": "(lootsurvivor::models::adventurer::bag::Bag, lootsurvivor::models::adventurer::item::Item)"
+                  "type": "(death_mountain::models::adventurer::bag::Bag, death_mountain::models::adventurer::item::Item)"
                 }
               ],
               "state_mutability": "view"
@@ -1846,7 +2214,7 @@
               "inputs": [
                 {
                   "name": "bag",
-                  "type": "lootsurvivor::models::adventurer::bag::Bag"
+                  "type": "death_mountain::models::adventurer::bag::Bag"
                 },
                 {
                   "name": "item_id",
@@ -1855,23 +2223,7 @@
               ],
               "outputs": [
                 {
-                  "type": "lootsurvivor::models::adventurer::bag::Bag"
-                }
-              ],
-              "state_mutability": "view"
-            },
-            {
-              "type": "function",
-              "name": "is_bag_full",
-              "inputs": [
-                {
-                  "name": "bag",
-                  "type": "lootsurvivor::models::adventurer::bag::Bag"
-                }
-              ],
-              "outputs": [
-                {
-                  "type": "core::bool"
+                  "type": "death_mountain::models::adventurer::bag::Bag"
                 }
               ],
               "state_mutability": "view"
@@ -1882,7 +2234,7 @@
               "inputs": [
                 {
                   "name": "bag",
-                  "type": "lootsurvivor::models::adventurer::bag::Bag"
+                  "type": "death_mountain::models::adventurer::bag::Bag"
                 },
                 {
                   "name": "item_id",
@@ -1891,7 +2243,7 @@
               ],
               "outputs": [
                 {
-                  "type": "(core::bool, lootsurvivor::models::adventurer::item::Item)"
+                  "type": "(core::bool, death_mountain::models::adventurer::item::Item)"
                 }
               ],
               "state_mutability": "view"
@@ -1945,8 +2297,16 @@
               "name": "get_market",
               "inputs": [
                 {
+                  "name": "adventurer_id",
+                  "type": "core::integer::u64"
+                },
+                {
                   "name": "seed",
                   "type": "core::integer::u64"
+                },
+                {
+                  "name": "market_size",
+                  "type": "core::integer::u8"
                 }
               ],
               "outputs": [
@@ -2057,7 +2417,7 @@
         },
         {
           "type": "event",
-          "name": "lootsurvivor::systems::adventurer::contracts::adventurer_systems::Event",
+          "name": "death_mountain::systems::adventurer::contracts::adventurer_systems::Event",
           "kind": "enum",
           "variants": [
             {
@@ -2074,15 +2434,16 @@
         }
       ],
       "init_calldata": [],
-      "tag": "ls_0_0_1-adventurer_systems",
-      "selector": "0x32e206b848fbf2b2f37f0e6722d601a13e51ffc7df5a0aceb677507f8bd43c5",
+      "tag": "ls_0_0_5-adventurer_systems",
+      "selector": "0x7d0fbab04f93dc32d8c022670b89c782800cb6be84b21c73ff90985924edd52",
       "systems": [
+        "record_item_drop",
         "upgrade"
       ]
     },
     {
-      "address": "0x68a1fa290d8dd5c054ab523cf9db412f6a3e105e3614ecdd332a28e60c5a6ef",
-      "class_hash": "0x583f95cd3dac90f31e127a4f57693254f4fa62a0a88b2487d607b60ad848f1b",
+      "address": "0x324d04ce74e00989db72d7fed1d2efd659f8b8f7f227050a7971e187ffc2f7",
+      "class_hash": "0x7406e9437f9b405c8152eb138b61818e66ce4f8a7526a22902e6fe631c75566",
       "abi": [
         {
           "type": "impl",
@@ -2137,11 +2498,129 @@
         {
           "type": "impl",
           "name": "BeastSystemsImpl",
-          "interface_name": "lootsurvivor::systems::beast::contracts::IBeastSystems"
+          "interface_name": "death_mountain::systems::beast::contracts::IBeastSystems"
         },
         {
           "type": "enum",
-          "name": "lootsurvivor::constants::combat::CombatEnums::Type",
+          "name": "death_mountain::models::game_data::DataResult::<(core::integer::u64, core::integer::u16, core::integer::u16)>",
+          "variants": [
+            {
+              "name": "Ok",
+              "type": "(core::integer::u64, core::integer::u16, core::integer::u16)"
+            },
+            {
+              "name": "Err",
+              "type": "core::felt252"
+            }
+          ]
+        },
+        {
+          "type": "struct",
+          "name": "death_mountain::models::game_data::CollectableEntity",
+          "members": [
+            {
+              "name": "dungeon",
+              "type": "core::starknet::contract_address::ContractAddress"
+            },
+            {
+              "name": "entity_hash",
+              "type": "core::felt252"
+            },
+            {
+              "name": "index",
+              "type": "core::integer::u64"
+            },
+            {
+              "name": "seed",
+              "type": "core::integer::u64"
+            },
+            {
+              "name": "id",
+              "type": "core::integer::u8"
+            },
+            {
+              "name": "level",
+              "type": "core::integer::u16"
+            },
+            {
+              "name": "health",
+              "type": "core::integer::u16"
+            },
+            {
+              "name": "prefix",
+              "type": "core::integer::u8"
+            },
+            {
+              "name": "suffix",
+              "type": "core::integer::u8"
+            },
+            {
+              "name": "killed_by",
+              "type": "core::integer::u64"
+            },
+            {
+              "name": "timestamp",
+              "type": "core::integer::u64"
+            }
+          ]
+        },
+        {
+          "type": "enum",
+          "name": "core::bool",
+          "variants": [
+            {
+              "name": "False",
+              "type": "()"
+            },
+            {
+              "name": "True",
+              "type": "()"
+            }
+          ]
+        },
+        {
+          "type": "struct",
+          "name": "death_mountain::models::game_data::EntityStats",
+          "members": [
+            {
+              "name": "dungeon",
+              "type": "core::starknet::contract_address::ContractAddress"
+            },
+            {
+              "name": "entity_hash",
+              "type": "core::felt252"
+            },
+            {
+              "name": "adventurers_killed",
+              "type": "core::integer::u64"
+            }
+          ]
+        },
+        {
+          "type": "struct",
+          "name": "death_mountain::models::game_data::AdventurerKilled",
+          "members": [
+            {
+              "name": "dungeon",
+              "type": "core::starknet::contract_address::ContractAddress"
+            },
+            {
+              "name": "entity_hash",
+              "type": "core::felt252"
+            },
+            {
+              "name": "kill_index",
+              "type": "core::integer::u64"
+            },
+            {
+              "name": "adventurer_id",
+              "type": "core::integer::u64"
+            }
+          ]
+        },
+        {
+          "type": "enum",
+          "name": "death_mountain::constants::combat::CombatEnums::Type",
           "variants": [
             {
               "name": "None",
@@ -2171,7 +2650,7 @@
         },
         {
           "type": "enum",
-          "name": "lootsurvivor::constants::combat::CombatEnums::Tier",
+          "name": "death_mountain::constants::combat::CombatEnums::Tier",
           "variants": [
             {
               "name": "None",
@@ -2201,7 +2680,7 @@
         },
         {
           "type": "struct",
-          "name": "lootsurvivor::models::combat::SpecialPowers",
+          "name": "death_mountain::models::combat::SpecialPowers",
           "members": [
             {
               "name": "special1",
@@ -2219,15 +2698,15 @@
         },
         {
           "type": "struct",
-          "name": "lootsurvivor::models::combat::CombatSpec",
+          "name": "death_mountain::models::combat::CombatSpec",
           "members": [
             {
               "name": "tier",
-              "type": "lootsurvivor::constants::combat::CombatEnums::Tier"
+              "type": "death_mountain::constants::combat::CombatEnums::Tier"
             },
             {
               "name": "item_type",
-              "type": "lootsurvivor::constants::combat::CombatEnums::Type"
+              "type": "death_mountain::constants::combat::CombatEnums::Type"
             },
             {
               "name": "level",
@@ -2235,13 +2714,13 @@
             },
             {
               "name": "specials",
-              "type": "lootsurvivor::models::combat::SpecialPowers"
+              "type": "death_mountain::models::combat::SpecialPowers"
             }
           ]
         },
         {
           "type": "struct",
-          "name": "lootsurvivor::models::beast::Beast",
+          "name": "death_mountain::models::beast::Beast",
           "members": [
             {
               "name": "id",
@@ -2253,40 +2732,254 @@
             },
             {
               "name": "combat_spec",
-              "type": "lootsurvivor::models::combat::CombatSpec"
-            }
-          ]
-        },
-        {
-          "type": "enum",
-          "name": "core::bool",
-          "variants": [
-            {
-              "name": "False",
-              "type": "()"
-            },
-            {
-              "name": "True",
-              "type": "()"
+              "type": "death_mountain::models::combat::CombatSpec"
             }
           ]
         },
         {
           "type": "interface",
-          "name": "lootsurvivor::systems::beast::contracts::IBeastSystems",
+          "name": "death_mountain::systems::beast::contracts::IBeastSystems",
           "items": [
+            {
+              "type": "function",
+              "name": "add_collectable",
+              "inputs": [
+                {
+                  "name": "seed",
+                  "type": "core::integer::u64"
+                },
+                {
+                  "name": "entity_id",
+                  "type": "core::integer::u8"
+                },
+                {
+                  "name": "level",
+                  "type": "core::integer::u16"
+                },
+                {
+                  "name": "health",
+                  "type": "core::integer::u16"
+                },
+                {
+                  "name": "prefix",
+                  "type": "core::integer::u8"
+                },
+                {
+                  "name": "suffix",
+                  "type": "core::integer::u8"
+                },
+                {
+                  "name": "adventurer_id",
+                  "type": "core::integer::u64"
+                }
+              ],
+              "outputs": [],
+              "state_mutability": "external"
+            },
+            {
+              "type": "function",
+              "name": "add_kill",
+              "inputs": [
+                {
+                  "name": "entity_hash",
+                  "type": "core::felt252"
+                },
+                {
+                  "name": "adventurer_id",
+                  "type": "core::integer::u64"
+                }
+              ],
+              "outputs": [],
+              "state_mutability": "external"
+            },
+            {
+              "type": "function",
+              "name": "premint_collectable",
+              "inputs": [
+                {
+                  "name": "seed",
+                  "type": "core::integer::u64"
+                },
+                {
+                  "name": "entity_id",
+                  "type": "core::integer::u8"
+                },
+                {
+                  "name": "prefix",
+                  "type": "core::integer::u8"
+                },
+                {
+                  "name": "suffix",
+                  "type": "core::integer::u8"
+                },
+                {
+                  "name": "level",
+                  "type": "core::integer::u16"
+                },
+                {
+                  "name": "health",
+                  "type": "core::integer::u16"
+                }
+              ],
+              "outputs": [
+                {
+                  "type": "core::integer::u64"
+                }
+              ],
+              "state_mutability": "external"
+            },
+            {
+              "type": "function",
+              "name": "get_valid_collectable",
+              "inputs": [
+                {
+                  "name": "dungeon",
+                  "type": "core::starknet::contract_address::ContractAddress"
+                },
+                {
+                  "name": "adventurer_id",
+                  "type": "core::integer::u64"
+                },
+                {
+                  "name": "entity_hash",
+                  "type": "core::felt252"
+                }
+              ],
+              "outputs": [
+                {
+                  "type": "death_mountain::models::game_data::DataResult::<(core::integer::u64, core::integer::u16, core::integer::u16)>"
+                }
+              ],
+              "state_mutability": "view"
+            },
+            {
+              "type": "function",
+              "name": "get_collectable",
+              "inputs": [
+                {
+                  "name": "dungeon",
+                  "type": "core::starknet::contract_address::ContractAddress"
+                },
+                {
+                  "name": "entity_hash",
+                  "type": "core::felt252"
+                },
+                {
+                  "name": "index",
+                  "type": "core::integer::u64"
+                }
+              ],
+              "outputs": [
+                {
+                  "type": "death_mountain::models::game_data::CollectableEntity"
+                }
+              ],
+              "state_mutability": "view"
+            },
+            {
+              "type": "function",
+              "name": "get_collectable_count",
+              "inputs": [
+                {
+                  "name": "dungeon",
+                  "type": "core::starknet::contract_address::ContractAddress"
+                },
+                {
+                  "name": "entity_hash",
+                  "type": "core::felt252"
+                }
+              ],
+              "outputs": [
+                {
+                  "type": "core::integer::u64"
+                }
+              ],
+              "state_mutability": "view"
+            },
+            {
+              "type": "function",
+              "name": "is_beast_collectable",
+              "inputs": [
+                {
+                  "name": "dungeon",
+                  "type": "core::starknet::contract_address::ContractAddress"
+                },
+                {
+                  "name": "beast_id",
+                  "type": "core::integer::u8"
+                },
+                {
+                  "name": "prefix",
+                  "type": "core::integer::u8"
+                },
+                {
+                  "name": "suffix",
+                  "type": "core::integer::u8"
+                }
+              ],
+              "outputs": [
+                {
+                  "type": "core::bool"
+                }
+              ],
+              "state_mutability": "view"
+            },
+            {
+              "type": "function",
+              "name": "get_entity_stats",
+              "inputs": [
+                {
+                  "name": "dungeon",
+                  "type": "core::starknet::contract_address::ContractAddress"
+                },
+                {
+                  "name": "entity_hash",
+                  "type": "core::felt252"
+                }
+              ],
+              "outputs": [
+                {
+                  "type": "death_mountain::models::game_data::EntityStats"
+                }
+              ],
+              "state_mutability": "view"
+            },
+            {
+              "type": "function",
+              "name": "get_adventurer_killed",
+              "inputs": [
+                {
+                  "name": "dungeon",
+                  "type": "core::starknet::contract_address::ContractAddress"
+                },
+                {
+                  "name": "entity_hash",
+                  "type": "core::felt252"
+                },
+                {
+                  "name": "kill_index",
+                  "type": "core::integer::u64"
+                }
+              ],
+              "outputs": [
+                {
+                  "type": "death_mountain::models::game_data::AdventurerKilled"
+                }
+              ],
+              "state_mutability": "view"
+            },
             {
               "type": "function",
               "name": "get_starter_beast",
               "inputs": [
                 {
                   "name": "starter_weapon_type",
-                  "type": "lootsurvivor::constants::combat::CombatEnums::Type"
+                  "type": "death_mountain::constants::combat::CombatEnums::Type"
                 }
               ],
               "outputs": [
                 {
-                  "type": "lootsurvivor::models::beast::Beast"
+                  "type": "death_mountain::models::beast::Beast"
                 }
               ],
               "state_mutability": "view"
@@ -2301,7 +2994,7 @@
                 },
                 {
                   "name": "weapon_type",
-                  "type": "lootsurvivor::constants::combat::CombatEnums::Type"
+                  "type": "death_mountain::constants::combat::CombatEnums::Type"
                 },
                 {
                   "name": "seed",
@@ -2326,51 +3019,7 @@
               ],
               "outputs": [
                 {
-                  "type": "lootsurvivor::models::beast::Beast"
-                }
-              ],
-              "state_mutability": "view"
-            },
-            {
-              "type": "function",
-              "name": "get_critical_hit_chance",
-              "inputs": [
-                {
-                  "name": "adventurer_level",
-                  "type": "core::integer::u8"
-                },
-                {
-                  "name": "is_ambush",
-                  "type": "core::bool"
-                }
-              ],
-              "outputs": [
-                {
-                  "type": "core::integer::u8"
-                }
-              ],
-              "state_mutability": "view"
-            },
-            {
-              "type": "function",
-              "name": "attempt_flee",
-              "inputs": [
-                {
-                  "name": "adventurer_level",
-                  "type": "core::integer::u8"
-                },
-                {
-                  "name": "adventurer_dexterity",
-                  "type": "core::integer::u8"
-                },
-                {
-                  "name": "rnd",
-                  "type": "core::integer::u8"
-                }
-              ],
-              "outputs": [
-                {
-                  "type": "core::bool"
+                  "type": "death_mountain::models::beast::Beast"
                 }
               ],
               "state_mutability": "view"
@@ -2476,7 +3125,7 @@
         },
         {
           "type": "event",
-          "name": "lootsurvivor::systems::beast::contracts::beast_systems::Event",
+          "name": "death_mountain::systems::beast::contracts::beast_systems::Event",
           "kind": "enum",
           "variants": [
             {
@@ -2493,15 +3142,18 @@
         }
       ],
       "init_calldata": [],
-      "tag": "ls_0_0_1-beast_systems",
-      "selector": "0x2684bca83d12f5bedb29b975f6e2dbca1350a43a0f98c2bcf272283d28ffefa",
+      "tag": "ls_0_0_5-beast_systems",
+      "selector": "0x38a8eeefb7859f38ba7f27d4161f012f04688488377ec0cc1def3a7d7af42c3",
       "systems": [
+        "add_collectable",
+        "add_kill",
+        "premint_collectable",
         "upgrade"
       ]
     },
     {
-      "address": "0x543fdf9d549d514dfe115363f090e67314f789daf1bdb33ca60710a8211f3e2",
-      "class_hash": "0x6a9270948419e6ec567454f7e99f963145a21e8f329ed4a81321290e6091dc2",
+      "address": "0x39d9adb951d94086d6a25d430a58391c7951f2e1e5fa37db0394a5a256002a7",
+      "class_hash": "0x70cf2ee3812c7d78b2fa1efff497376927b1d6b41d4124a2abbf1e8508d0184",
       "abi": [
         {
           "type": "impl",
@@ -2556,7 +3208,7 @@
         {
           "type": "impl",
           "name": "GameSystemsImpl",
-          "interface_name": "lootsurvivor::systems::game::contracts::IGameSystems"
+          "interface_name": "death_mountain::systems::game::contracts::IGameSystems"
         },
         {
           "type": "enum",
@@ -2574,7 +3226,7 @@
         },
         {
           "type": "struct",
-          "name": "lootsurvivor::models::market::ItemPurchase",
+          "name": "death_mountain::models::market::ItemPurchase",
           "members": [
             {
               "name": "item_id",
@@ -2588,7 +3240,7 @@
         },
         {
           "type": "struct",
-          "name": "lootsurvivor::models::adventurer::stats::Stats",
+          "name": "death_mountain::models::adventurer::stats::Stats",
           "members": [
             {
               "name": "strength",
@@ -2622,7 +3274,7 @@
         },
         {
           "type": "interface",
-          "name": "lootsurvivor::systems::game::contracts::IGameSystems",
+          "name": "death_mountain::systems::game::contracts::IGameSystems",
           "items": [
             {
               "type": "function",
@@ -2734,7 +3386,7 @@
                 },
                 {
                   "name": "items",
-                  "type": "core::array::Array::<lootsurvivor::models::market::ItemPurchase>"
+                  "type": "core::array::Array::<death_mountain::models::market::ItemPurchase>"
                 }
               ],
               "outputs": [],
@@ -2750,7 +3402,7 @@
                 },
                 {
                   "name": "stat_upgrades",
-                  "type": "lootsurvivor::models::adventurer::stats::Stats"
+                  "type": "death_mountain::models::adventurer::stats::Stats"
                 }
               ],
               "outputs": [],
@@ -2857,7 +3509,7 @@
         },
         {
           "type": "event",
-          "name": "lootsurvivor::systems::game::contracts::game_systems::Event",
+          "name": "death_mountain::systems::game::contracts::game_systems::Event",
           "kind": "enum",
           "variants": [
             {
@@ -2874,8 +3526,8 @@
         }
       ],
       "init_calldata": [],
-      "tag": "ls_0_0_1-game_systems",
-      "selector": "0x480e2d16e9a394219b17309619ec764b9b85540b274ff636b668bb6585adf58",
+      "tag": "ls_0_0_5-game_systems",
+      "selector": "0x7f39beb2acb5a3124d98601d40acad8d4263ee9f4e0915fbf5c0dce1c76358e",
       "systems": [
         "start_game",
         "explore",
@@ -2889,8 +3541,8 @@
       ]
     },
     {
-      "address": "0x6f261eba018dda4f60bdc1d0874cb7e97bf424979dda63fcbdf8bdcba1fb644",
-      "class_hash": "0x4168f47735bf74c8c6fcbb5f79061aa2a6e138bef24e3af5a7de0c91ca5cdda",
+      "address": "0x5111300a337dfb892fda7e594a80c229f239caf0f337dc864b681b9a77555b7",
+      "class_hash": "0x54fbd3cc638c4ba0ba84d4101ae88e03c89e6998badd412f3c7eff45d106814",
       "abi": [
         {
           "type": "impl",
@@ -2949,6 +3601,10 @@
             {
               "name": "creator_address",
               "type": "core::starknet::contract_address::ContractAddress"
+            },
+            {
+              "name": "denshokan_address",
+              "type": "core::starknet::contract_address::ContractAddress"
             }
           ],
           "outputs": [],
@@ -2956,8 +3612,8 @@
         },
         {
           "type": "impl",
-          "name": "SettingsImpl",
-          "interface_name": "tournaments::components::interfaces::ISettings"
+          "name": "GameTokenDataImpl",
+          "interface_name": "game_components_minigame::interface::IMinigameTokenData"
         },
         {
           "type": "enum",
@@ -2975,15 +3631,31 @@
         },
         {
           "type": "interface",
-          "name": "tournaments::components::interfaces::ISettings",
+          "name": "game_components_minigame::interface::IMinigameTokenData",
           "items": [
             {
               "type": "function",
-              "name": "setting_exists",
+              "name": "score",
               "inputs": [
                 {
-                  "name": "settings_id",
+                  "name": "token_id",
+                  "type": "core::integer::u64"
+                }
+              ],
+              "outputs": [
+                {
                   "type": "core::integer::u32"
+                }
+              ],
+              "state_mutability": "view"
+            },
+            {
+              "type": "function",
+              "name": "game_over",
+              "inputs": [
+                {
+                  "name": "token_id",
+                  "type": "core::integer::u64"
                 }
               ],
               "outputs": [
@@ -2997,25 +3669,85 @@
         },
         {
           "type": "impl",
-          "name": "GameDetailsImpl",
-          "interface_name": "tournaments::components::interfaces::IGameDetails"
+          "name": "ObjectivesImpl",
+          "interface_name": "game_components_minigame::extensions::objectives::interface::IMinigameObjectives"
+        },
+        {
+          "type": "struct",
+          "name": "game_components_minigame::extensions::objectives::structs::GameObjective",
+          "members": [
+            {
+              "name": "name",
+              "type": "core::byte_array::ByteArray"
+            },
+            {
+              "name": "value",
+              "type": "core::byte_array::ByteArray"
+            }
+          ]
+        },
+        {
+          "type": "struct",
+          "name": "core::array::Span::<game_components_minigame::extensions::objectives::structs::GameObjective>",
+          "members": [
+            {
+              "name": "snapshot",
+              "type": "@core::array::Array::<game_components_minigame::extensions::objectives::structs::GameObjective>"
+            }
+          ]
         },
         {
           "type": "interface",
-          "name": "tournaments::components::interfaces::IGameDetails",
+          "name": "game_components_minigame::extensions::objectives::interface::IMinigameObjectives",
           "items": [
             {
               "type": "function",
-              "name": "score",
+              "name": "objective_exists",
               "inputs": [
                 {
-                  "name": "game_id",
+                  "name": "objective_id",
+                  "type": "core::integer::u32"
+                }
+              ],
+              "outputs": [
+                {
+                  "type": "core::bool"
+                }
+              ],
+              "state_mutability": "view"
+            },
+            {
+              "type": "function",
+              "name": "completed_objective",
+              "inputs": [
+                {
+                  "name": "token_id",
+                  "type": "core::integer::u64"
+                },
+                {
+                  "name": "objective_id",
+                  "type": "core::integer::u32"
+                }
+              ],
+              "outputs": [
+                {
+                  "type": "core::bool"
+                }
+              ],
+              "state_mutability": "view"
+            },
+            {
+              "type": "function",
+              "name": "objectives",
+              "inputs": [
+                {
+                  "name": "token_id",
                   "type": "core::integer::u64"
                 }
               ],
               "outputs": [
                 {
-                  "type": "core::integer::u32"
+                  "type": "core::array::Span::<game_components_minigame::extensions::objectives::structs::GameObjective>"
                 }
               ],
               "state_mutability": "view"
@@ -3024,56 +3756,32 @@
         },
         {
           "type": "impl",
-          "name": "ERC721Metadata",
-          "interface_name": "openzeppelin_token::erc721::interface::IERC721Metadata"
-        },
-        {
-          "type": "struct",
-          "name": "core::integer::u256",
-          "members": [
-            {
-              "name": "low",
-              "type": "core::integer::u128"
-            },
-            {
-              "name": "high",
-              "type": "core::integer::u128"
-            }
-          ]
+          "name": "GameTokenSystemsImpl",
+          "interface_name": "death_mountain::systems::game_token::contracts::IGameTokenSystems"
         },
         {
           "type": "interface",
-          "name": "openzeppelin_token::erc721::interface::IERC721Metadata",
+          "name": "death_mountain::systems::game_token::contracts::IGameTokenSystems",
           "items": [
             {
               "type": "function",
-              "name": "name",
-              "inputs": [],
-              "outputs": [
-                {
-                  "type": "core::byte_array::ByteArray"
-                }
-              ],
-              "state_mutability": "view"
-            },
-            {
-              "type": "function",
-              "name": "symbol",
-              "inputs": [],
-              "outputs": [
-                {
-                  "type": "core::byte_array::ByteArray"
-                }
-              ],
-              "state_mutability": "view"
-            },
-            {
-              "type": "function",
-              "name": "token_uri",
+              "name": "create_objective",
               "inputs": [
                 {
-                  "name": "token_id",
-                  "type": "core::integer::u256"
+                  "name": "score",
+                  "type": "core::integer::u32"
+                }
+              ],
+              "outputs": [],
+              "state_mutability": "external"
+            },
+            {
+              "type": "function",
+              "name": "player_name",
+              "inputs": [
+                {
+                  "name": "adventurer_id",
+                  "type": "core::integer::u64"
                 }
               ],
               "outputs": [
@@ -3081,7 +3789,7 @@
                   "type": "core::byte_array::ByteArray"
                 }
               ],
-              "state_mutability": "view"
+              "state_mutability": "external"
             }
           ]
         },
@@ -3142,8 +3850,36 @@
         },
         {
           "type": "impl",
-          "name": "GameImpl",
-          "interface_name": "tournaments::components::interfaces::IGameToken"
+          "name": "MinigameImpl",
+          "interface_name": "game_components_minigame::interface::IMinigame"
+        },
+        {
+          "type": "enum",
+          "name": "core::option::Option::<core::byte_array::ByteArray>",
+          "variants": [
+            {
+              "name": "Some",
+              "type": "core::byte_array::ByteArray"
+            },
+            {
+              "name": "None",
+              "type": "()"
+            }
+          ]
+        },
+        {
+          "type": "enum",
+          "name": "core::option::Option::<core::integer::u32>",
+          "variants": [
+            {
+              "name": "Some",
+              "type": "core::integer::u32"
+            },
+            {
+              "name": "None",
+              "type": "()"
+            }
+          ]
         },
         {
           "type": "enum",
@@ -3161,101 +3897,150 @@
         },
         {
           "type": "struct",
-          "name": "tournaments::components::models::game::GameMetadata",
+          "name": "core::array::Span::<core::integer::u32>",
           "members": [
             {
-              "name": "contract_address",
-              "type": "core::starknet::contract_address::ContractAddress"
+              "name": "snapshot",
+              "type": "@core::array::Array::<core::integer::u32>"
+            }
+          ]
+        },
+        {
+          "type": "enum",
+          "name": "core::option::Option::<core::array::Span::<core::integer::u32>>",
+          "variants": [
+            {
+              "name": "Some",
+              "type": "core::array::Span::<core::integer::u32>"
             },
             {
-              "name": "creator_address",
-              "type": "core::starknet::contract_address::ContractAddress"
-            },
+              "name": "None",
+              "type": "()"
+            }
+          ]
+        },
+        {
+          "type": "struct",
+          "name": "game_components_metagame::extensions::context::structs::GameContext",
+          "members": [
             {
               "name": "name",
-              "type": "core::felt252"
+              "type": "core::byte_array::ByteArray"
+            },
+            {
+              "name": "value",
+              "type": "core::byte_array::ByteArray"
+            }
+          ]
+        },
+        {
+          "type": "struct",
+          "name": "core::array::Span::<game_components_metagame::extensions::context::structs::GameContext>",
+          "members": [
+            {
+              "name": "snapshot",
+              "type": "@core::array::Array::<game_components_metagame::extensions::context::structs::GameContext>"
+            }
+          ]
+        },
+        {
+          "type": "struct",
+          "name": "game_components_metagame::extensions::context::structs::GameContextDetails",
+          "members": [
+            {
+              "name": "name",
+              "type": "core::byte_array::ByteArray"
             },
             {
               "name": "description",
               "type": "core::byte_array::ByteArray"
             },
             {
-              "name": "developer",
-              "type": "core::felt252"
+              "name": "id",
+              "type": "core::option::Option::<core::integer::u32>"
             },
             {
-              "name": "publisher",
-              "type": "core::felt252"
-            },
-            {
-              "name": "genre",
-              "type": "core::felt252"
-            },
-            {
-              "name": "image",
-              "type": "core::byte_array::ByteArray"
+              "name": "context",
+              "type": "core::array::Span::<game_components_metagame::extensions::context::structs::GameContext>"
             }
           ]
         },
         {
-          "type": "struct",
-          "name": "tournaments::components::models::lifecycle::Lifecycle",
-          "members": [
+          "type": "enum",
+          "name": "core::option::Option::<game_components_metagame::extensions::context::structs::GameContextDetails>",
+          "variants": [
             {
-              "name": "mint",
-              "type": "core::integer::u64"
+              "name": "Some",
+              "type": "game_components_metagame::extensions::context::structs::GameContextDetails"
             },
             {
-              "name": "start",
-              "type": "core::option::Option::<core::integer::u64>"
-            },
-            {
-              "name": "end",
-              "type": "core::option::Option::<core::integer::u64>"
+              "name": "None",
+              "type": "()"
             }
           ]
         },
         {
-          "type": "struct",
-          "name": "tournaments::components::models::game::TokenMetadata",
-          "members": [
+          "type": "enum",
+          "name": "core::option::Option::<core::starknet::contract_address::ContractAddress>",
+          "variants": [
             {
-              "name": "token_id",
-              "type": "core::integer::u64"
-            },
-            {
-              "name": "minted_by",
+              "name": "Some",
               "type": "core::starknet::contract_address::ContractAddress"
             },
             {
-              "name": "player_name",
-              "type": "core::felt252"
-            },
-            {
-              "name": "settings_id",
-              "type": "core::integer::u32"
-            },
-            {
-              "name": "lifecycle",
-              "type": "tournaments::components::models::lifecycle::Lifecycle"
+              "name": "None",
+              "type": "()"
             }
           ]
         },
         {
           "type": "interface",
-          "name": "tournaments::components::interfaces::IGameToken",
+          "name": "game_components_minigame::interface::IMinigame",
           "items": [
             {
               "type": "function",
-              "name": "mint",
+              "name": "token_address",
+              "inputs": [],
+              "outputs": [
+                {
+                  "type": "core::starknet::contract_address::ContractAddress"
+                }
+              ],
+              "state_mutability": "view"
+            },
+            {
+              "type": "function",
+              "name": "settings_address",
+              "inputs": [],
+              "outputs": [
+                {
+                  "type": "core::starknet::contract_address::ContractAddress"
+                }
+              ],
+              "state_mutability": "view"
+            },
+            {
+              "type": "function",
+              "name": "objectives_address",
+              "inputs": [],
+              "outputs": [
+                {
+                  "type": "core::starknet::contract_address::ContractAddress"
+                }
+              ],
+              "state_mutability": "view"
+            },
+            {
+              "type": "function",
+              "name": "mint_game",
               "inputs": [
                 {
                   "name": "player_name",
-                  "type": "core::felt252"
+                  "type": "core::option::Option::<core::byte_array::ByteArray>"
                 },
                 {
                   "name": "settings_id",
-                  "type": "core::integer::u32"
+                  "type": "core::option::Option::<core::integer::u32>"
                 },
                 {
                   "name": "start",
@@ -3266,411 +4051,33 @@
                   "type": "core::option::Option::<core::integer::u64>"
                 },
                 {
+                  "name": "objective_ids",
+                  "type": "core::option::Option::<core::array::Span::<core::integer::u32>>"
+                },
+                {
+                  "name": "context",
+                  "type": "core::option::Option::<game_components_metagame::extensions::context::structs::GameContextDetails>"
+                },
+                {
+                  "name": "client_url",
+                  "type": "core::option::Option::<core::byte_array::ByteArray>"
+                },
+                {
+                  "name": "renderer_address",
+                  "type": "core::option::Option::<core::starknet::contract_address::ContractAddress>"
+                },
+                {
                   "name": "to",
                   "type": "core::starknet::contract_address::ContractAddress"
+                },
+                {
+                  "name": "soulbound",
+                  "type": "core::bool"
                 }
               ],
               "outputs": [
                 {
                   "type": "core::integer::u64"
-                }
-              ],
-              "state_mutability": "external"
-            },
-            {
-              "type": "function",
-              "name": "emit_metadata_update",
-              "inputs": [
-                {
-                  "name": "game_id",
-                  "type": "core::integer::u64"
-                }
-              ],
-              "outputs": [],
-              "state_mutability": "external"
-            },
-            {
-              "type": "function",
-              "name": "game_metadata",
-              "inputs": [],
-              "outputs": [
-                {
-                  "type": "tournaments::components::models::game::GameMetadata"
-                }
-              ],
-              "state_mutability": "view"
-            },
-            {
-              "type": "function",
-              "name": "token_metadata",
-              "inputs": [
-                {
-                  "name": "token_id",
-                  "type": "core::integer::u64"
-                }
-              ],
-              "outputs": [
-                {
-                  "type": "tournaments::components::models::game::TokenMetadata"
-                }
-              ],
-              "state_mutability": "view"
-            },
-            {
-              "type": "function",
-              "name": "game_count",
-              "inputs": [],
-              "outputs": [
-                {
-                  "type": "core::integer::u64"
-                }
-              ],
-              "state_mutability": "view"
-            },
-            {
-              "type": "function",
-              "name": "namespace",
-              "inputs": [],
-              "outputs": [
-                {
-                  "type": "core::byte_array::ByteArray"
-                }
-              ],
-              "state_mutability": "view"
-            },
-            {
-              "type": "function",
-              "name": "score_model",
-              "inputs": [],
-              "outputs": [
-                {
-                  "type": "core::byte_array::ByteArray"
-                }
-              ],
-              "state_mutability": "view"
-            },
-            {
-              "type": "function",
-              "name": "score_attribute",
-              "inputs": [],
-              "outputs": [
-                {
-                  "type": "core::byte_array::ByteArray"
-                }
-              ],
-              "state_mutability": "view"
-            },
-            {
-              "type": "function",
-              "name": "settings_model",
-              "inputs": [],
-              "outputs": [
-                {
-                  "type": "core::byte_array::ByteArray"
-                }
-              ],
-              "state_mutability": "view"
-            }
-          ]
-        },
-        {
-          "type": "impl",
-          "name": "ERC721Impl",
-          "interface_name": "openzeppelin_token::erc721::interface::IERC721"
-        },
-        {
-          "type": "struct",
-          "name": "core::array::Span::<core::felt252>",
-          "members": [
-            {
-              "name": "snapshot",
-              "type": "@core::array::Array::<core::felt252>"
-            }
-          ]
-        },
-        {
-          "type": "interface",
-          "name": "openzeppelin_token::erc721::interface::IERC721",
-          "items": [
-            {
-              "type": "function",
-              "name": "balance_of",
-              "inputs": [
-                {
-                  "name": "account",
-                  "type": "core::starknet::contract_address::ContractAddress"
-                }
-              ],
-              "outputs": [
-                {
-                  "type": "core::integer::u256"
-                }
-              ],
-              "state_mutability": "view"
-            },
-            {
-              "type": "function",
-              "name": "owner_of",
-              "inputs": [
-                {
-                  "name": "token_id",
-                  "type": "core::integer::u256"
-                }
-              ],
-              "outputs": [
-                {
-                  "type": "core::starknet::contract_address::ContractAddress"
-                }
-              ],
-              "state_mutability": "view"
-            },
-            {
-              "type": "function",
-              "name": "safe_transfer_from",
-              "inputs": [
-                {
-                  "name": "from",
-                  "type": "core::starknet::contract_address::ContractAddress"
-                },
-                {
-                  "name": "to",
-                  "type": "core::starknet::contract_address::ContractAddress"
-                },
-                {
-                  "name": "token_id",
-                  "type": "core::integer::u256"
-                },
-                {
-                  "name": "data",
-                  "type": "core::array::Span::<core::felt252>"
-                }
-              ],
-              "outputs": [],
-              "state_mutability": "external"
-            },
-            {
-              "type": "function",
-              "name": "transfer_from",
-              "inputs": [
-                {
-                  "name": "from",
-                  "type": "core::starknet::contract_address::ContractAddress"
-                },
-                {
-                  "name": "to",
-                  "type": "core::starknet::contract_address::ContractAddress"
-                },
-                {
-                  "name": "token_id",
-                  "type": "core::integer::u256"
-                }
-              ],
-              "outputs": [],
-              "state_mutability": "external"
-            },
-            {
-              "type": "function",
-              "name": "approve",
-              "inputs": [
-                {
-                  "name": "to",
-                  "type": "core::starknet::contract_address::ContractAddress"
-                },
-                {
-                  "name": "token_id",
-                  "type": "core::integer::u256"
-                }
-              ],
-              "outputs": [],
-              "state_mutability": "external"
-            },
-            {
-              "type": "function",
-              "name": "set_approval_for_all",
-              "inputs": [
-                {
-                  "name": "operator",
-                  "type": "core::starknet::contract_address::ContractAddress"
-                },
-                {
-                  "name": "approved",
-                  "type": "core::bool"
-                }
-              ],
-              "outputs": [],
-              "state_mutability": "external"
-            },
-            {
-              "type": "function",
-              "name": "get_approved",
-              "inputs": [
-                {
-                  "name": "token_id",
-                  "type": "core::integer::u256"
-                }
-              ],
-              "outputs": [
-                {
-                  "type": "core::starknet::contract_address::ContractAddress"
-                }
-              ],
-              "state_mutability": "view"
-            },
-            {
-              "type": "function",
-              "name": "is_approved_for_all",
-              "inputs": [
-                {
-                  "name": "owner",
-                  "type": "core::starknet::contract_address::ContractAddress"
-                },
-                {
-                  "name": "operator",
-                  "type": "core::starknet::contract_address::ContractAddress"
-                }
-              ],
-              "outputs": [
-                {
-                  "type": "core::bool"
-                }
-              ],
-              "state_mutability": "view"
-            }
-          ]
-        },
-        {
-          "type": "impl",
-          "name": "ERC721CamelOnlyImpl",
-          "interface_name": "openzeppelin_token::erc721::interface::IERC721CamelOnly"
-        },
-        {
-          "type": "interface",
-          "name": "openzeppelin_token::erc721::interface::IERC721CamelOnly",
-          "items": [
-            {
-              "type": "function",
-              "name": "balanceOf",
-              "inputs": [
-                {
-                  "name": "account",
-                  "type": "core::starknet::contract_address::ContractAddress"
-                }
-              ],
-              "outputs": [
-                {
-                  "type": "core::integer::u256"
-                }
-              ],
-              "state_mutability": "view"
-            },
-            {
-              "type": "function",
-              "name": "ownerOf",
-              "inputs": [
-                {
-                  "name": "tokenId",
-                  "type": "core::integer::u256"
-                }
-              ],
-              "outputs": [
-                {
-                  "type": "core::starknet::contract_address::ContractAddress"
-                }
-              ],
-              "state_mutability": "view"
-            },
-            {
-              "type": "function",
-              "name": "safeTransferFrom",
-              "inputs": [
-                {
-                  "name": "from",
-                  "type": "core::starknet::contract_address::ContractAddress"
-                },
-                {
-                  "name": "to",
-                  "type": "core::starknet::contract_address::ContractAddress"
-                },
-                {
-                  "name": "tokenId",
-                  "type": "core::integer::u256"
-                },
-                {
-                  "name": "data",
-                  "type": "core::array::Span::<core::felt252>"
-                }
-              ],
-              "outputs": [],
-              "state_mutability": "external"
-            },
-            {
-              "type": "function",
-              "name": "transferFrom",
-              "inputs": [
-                {
-                  "name": "from",
-                  "type": "core::starknet::contract_address::ContractAddress"
-                },
-                {
-                  "name": "to",
-                  "type": "core::starknet::contract_address::ContractAddress"
-                },
-                {
-                  "name": "tokenId",
-                  "type": "core::integer::u256"
-                }
-              ],
-              "outputs": [],
-              "state_mutability": "external"
-            },
-            {
-              "type": "function",
-              "name": "setApprovalForAll",
-              "inputs": [
-                {
-                  "name": "operator",
-                  "type": "core::starknet::contract_address::ContractAddress"
-                },
-                {
-                  "name": "approved",
-                  "type": "core::bool"
-                }
-              ],
-              "outputs": [],
-              "state_mutability": "external"
-            },
-            {
-              "type": "function",
-              "name": "getApproved",
-              "inputs": [
-                {
-                  "name": "tokenId",
-                  "type": "core::integer::u256"
-                }
-              ],
-              "outputs": [
-                {
-                  "type": "core::starknet::contract_address::ContractAddress"
-                }
-              ],
-              "state_mutability": "view"
-            },
-            {
-              "type": "function",
-              "name": "isApprovedForAll",
-              "inputs": [
-                {
-                  "name": "owner",
-                  "type": "core::starknet::contract_address::ContractAddress"
-                },
-                {
-                  "name": "operator",
-                  "type": "core::starknet::contract_address::ContractAddress"
-                }
-              ],
-              "outputs": [
-                {
-                  "type": "core::bool"
                 }
               ],
               "state_mutability": "view"
@@ -3741,115 +4148,15 @@
         },
         {
           "type": "event",
-          "name": "tournaments::components::game::game_component::MetadataUpdateEvent",
-          "kind": "struct",
-          "members": [
-            {
-              "name": "token_id",
-              "type": "core::integer::u256",
-              "kind": "key"
-            }
-          ]
-        },
-        {
-          "type": "event",
-          "name": "tournaments::components::game::game_component::Event",
+          "name": "game_components_minigame::minigame::MinigameComponent::Event",
           "kind": "enum",
-          "variants": [
-            {
-              "name": "MetadataUpdate",
-              "type": "tournaments::components::game::game_component::MetadataUpdateEvent",
-              "kind": "nested"
-            }
-          ]
+          "variants": []
         },
         {
           "type": "event",
-          "name": "openzeppelin_token::erc721::erc721::ERC721Component::Transfer",
-          "kind": "struct",
-          "members": [
-            {
-              "name": "from",
-              "type": "core::starknet::contract_address::ContractAddress",
-              "kind": "key"
-            },
-            {
-              "name": "to",
-              "type": "core::starknet::contract_address::ContractAddress",
-              "kind": "key"
-            },
-            {
-              "name": "token_id",
-              "type": "core::integer::u256",
-              "kind": "key"
-            }
-          ]
-        },
-        {
-          "type": "event",
-          "name": "openzeppelin_token::erc721::erc721::ERC721Component::Approval",
-          "kind": "struct",
-          "members": [
-            {
-              "name": "owner",
-              "type": "core::starknet::contract_address::ContractAddress",
-              "kind": "key"
-            },
-            {
-              "name": "approved",
-              "type": "core::starknet::contract_address::ContractAddress",
-              "kind": "key"
-            },
-            {
-              "name": "token_id",
-              "type": "core::integer::u256",
-              "kind": "key"
-            }
-          ]
-        },
-        {
-          "type": "event",
-          "name": "openzeppelin_token::erc721::erc721::ERC721Component::ApprovalForAll",
-          "kind": "struct",
-          "members": [
-            {
-              "name": "owner",
-              "type": "core::starknet::contract_address::ContractAddress",
-              "kind": "key"
-            },
-            {
-              "name": "operator",
-              "type": "core::starknet::contract_address::ContractAddress",
-              "kind": "key"
-            },
-            {
-              "name": "approved",
-              "type": "core::bool",
-              "kind": "data"
-            }
-          ]
-        },
-        {
-          "type": "event",
-          "name": "openzeppelin_token::erc721::erc721::ERC721Component::Event",
+          "name": "game_components_minigame::extensions::objectives::objectives::ObjectivesComponent::Event",
           "kind": "enum",
-          "variants": [
-            {
-              "name": "Transfer",
-              "type": "openzeppelin_token::erc721::erc721::ERC721Component::Transfer",
-              "kind": "nested"
-            },
-            {
-              "name": "Approval",
-              "type": "openzeppelin_token::erc721::erc721::ERC721Component::Approval",
-              "kind": "nested"
-            },
-            {
-              "name": "ApprovalForAll",
-              "type": "openzeppelin_token::erc721::erc721::ERC721Component::ApprovalForAll",
-              "kind": "nested"
-            }
-          ]
+          "variants": []
         },
         {
           "type": "event",
@@ -3859,7 +4166,7 @@
         },
         {
           "type": "event",
-          "name": "lootsurvivor::systems::game_token::contracts::game_token_systems::Event",
+          "name": "death_mountain::systems::game_token::contracts::game_token_systems::Event",
           "kind": "enum",
           "variants": [
             {
@@ -3873,13 +4180,13 @@
               "kind": "nested"
             },
             {
-              "name": "GameEvent",
-              "type": "tournaments::components::game::game_component::Event",
+              "name": "MinigameEvent",
+              "type": "game_components_minigame::minigame::MinigameComponent::Event",
               "kind": "flat"
             },
             {
-              "name": "ERC721Event",
-              "type": "openzeppelin_token::erc721::erc721::ERC721Component::Event",
+              "name": "ObjectivesEvent",
+              "type": "game_components_minigame::extensions::objectives::objectives::ObjectivesComponent::Event",
               "kind": "flat"
             },
             {
@@ -3891,27 +4198,21 @@
         }
       ],
       "init_calldata": [
-        "0x0238df9Efd27Aba2ccB0bdC97a4cf440caA403e9ed3f1883294Ab6CDBA6C5282"
+        "0x065d2AB17338b5AffdEbAF95E2D79834B5f30Bac596fF55563c62C3c98700150",
+        "0x01fd7f186c0bb99f8d128f1eb40dbe3c7657df381957417f8c9a40804c005545"
       ],
-      "tag": "ls_0_0_1-game_token_systems",
-      "selector": "0x2e56d1c33ee39d46198aaa6a699e72b6f445eacc243ef2e61719e4198af9aed",
+      "tag": "ls_0_0_5-game_token_systems",
+      "selector": "0x56361f0ad3f6ec1de7434cf73b2338cbd47a310909ba2d7a0df86640b561982",
       "systems": [
         "dojo_init",
-        "upgrade",
-        "mint",
-        "emit_metadata_update",
-        "safe_transfer_from",
-        "transfer_from",
-        "approve",
-        "set_approval_for_all",
-        "safeTransferFrom",
-        "transferFrom",
-        "setApprovalForAll"
+        "create_objective",
+        "player_name",
+        "upgrade"
       ]
     },
     {
-      "address": "0x513026b65c44bf5843efa2fe925d311ae1593a589bceb74ec0e704df652d770",
-      "class_hash": "0x5cdf1657b5f1a819c446069e6a51ab19d209ee4ae842d6168da8895a90bb6ff",
+      "address": "0x301e2400c9eb8c84c576506c890721537ca0960a73c75d42943a0965aa789ae",
+      "class_hash": "0x23cdb494302994de197966707c72df5708f2516f5205ed398dacb4c16fc4bcc",
       "abi": [
         {
           "type": "impl",
@@ -3966,11 +4267,11 @@
         {
           "type": "impl",
           "name": "LootSystemsImpl",
-          "interface_name": "lootsurvivor::systems::loot::contracts::ILootSystems"
+          "interface_name": "death_mountain::systems::loot::contracts::ILootSystems"
         },
         {
           "type": "enum",
-          "name": "lootsurvivor::constants::combat::CombatEnums::Tier",
+          "name": "death_mountain::constants::combat::CombatEnums::Tier",
           "variants": [
             {
               "name": "None",
@@ -4000,7 +4301,7 @@
         },
         {
           "type": "enum",
-          "name": "lootsurvivor::constants::combat::CombatEnums::Type",
+          "name": "death_mountain::constants::combat::CombatEnums::Type",
           "variants": [
             {
               "name": "None",
@@ -4030,7 +4331,7 @@
         },
         {
           "type": "enum",
-          "name": "lootsurvivor::constants::combat::CombatEnums::Slot",
+          "name": "death_mountain::constants::combat::CombatEnums::Slot",
           "variants": [
             {
               "name": "None",
@@ -4072,7 +4373,7 @@
         },
         {
           "type": "struct",
-          "name": "lootsurvivor::models::loot::Loot",
+          "name": "death_mountain::models::loot::Loot",
           "members": [
             {
               "name": "id",
@@ -4080,21 +4381,21 @@
             },
             {
               "name": "tier",
-              "type": "lootsurvivor::constants::combat::CombatEnums::Tier"
+              "type": "death_mountain::constants::combat::CombatEnums::Tier"
             },
             {
               "name": "item_type",
-              "type": "lootsurvivor::constants::combat::CombatEnums::Type"
+              "type": "death_mountain::constants::combat::CombatEnums::Type"
             },
             {
               "name": "slot",
-              "type": "lootsurvivor::constants::combat::CombatEnums::Slot"
+              "type": "death_mountain::constants::combat::CombatEnums::Slot"
             }
           ]
         },
         {
           "type": "struct",
-          "name": "lootsurvivor::models::combat::SpecialPowers",
+          "name": "death_mountain::models::combat::SpecialPowers",
           "members": [
             {
               "name": "special1",
@@ -4126,7 +4427,7 @@
         },
         {
           "type": "interface",
-          "name": "lootsurvivor::systems::loot::contracts::ILootSystems",
+          "name": "death_mountain::systems::loot::contracts::ILootSystems",
           "items": [
             {
               "type": "function",
@@ -4139,7 +4440,7 @@
               ],
               "outputs": [
                 {
-                  "type": "lootsurvivor::models::loot::Loot"
+                  "type": "death_mountain::models::loot::Loot"
                 }
               ],
               "state_mutability": "view"
@@ -4163,7 +4464,7 @@
               ],
               "outputs": [
                 {
-                  "type": "lootsurvivor::models::combat::SpecialPowers"
+                  "type": "death_mountain::models::combat::SpecialPowers"
                 }
               ],
               "state_mutability": "view"
@@ -4239,7 +4540,7 @@
               ],
               "outputs": [
                 {
-                  "type": "lootsurvivor::constants::combat::CombatEnums::Tier"
+                  "type": "death_mountain::constants::combat::CombatEnums::Tier"
                 }
               ],
               "state_mutability": "view"
@@ -4255,7 +4556,7 @@
               ],
               "outputs": [
                 {
-                  "type": "lootsurvivor::constants::combat::CombatEnums::Type"
+                  "type": "death_mountain::constants::combat::CombatEnums::Type"
                 }
               ],
               "state_mutability": "view"
@@ -4271,7 +4572,7 @@
               ],
               "outputs": [
                 {
-                  "type": "lootsurvivor::constants::combat::CombatEnums::Slot"
+                  "type": "death_mountain::constants::combat::CombatEnums::Slot"
                 }
               ],
               "state_mutability": "view"
@@ -4393,7 +4694,7 @@
         },
         {
           "type": "event",
-          "name": "lootsurvivor::systems::loot::contracts::loot_systems::Event",
+          "name": "death_mountain::systems::loot::contracts::loot_systems::Event",
           "kind": "enum",
           "variants": [
             {
@@ -4410,15 +4711,15 @@
         }
       ],
       "init_calldata": [],
-      "tag": "ls_0_0_1-loot_systems",
-      "selector": "0x6998739723690a00c04f7580a32efaaf4a2a2396850c3d16fb1b2257cc40491",
+      "tag": "ls_0_0_5-loot_systems",
+      "selector": "0x2b044fad5c186f2ed66b548cbd7f3e7b80fd69b2c9b54f35723dc1a7d842220",
       "systems": [
         "upgrade"
       ]
     },
     {
-      "address": "0x165e98ddaea22ef835a18b01846054d40db39a2f3ec06ce2e6718a44d018680",
-      "class_hash": "0x13e9803640598ac36f27778b3337f1b34a3b0adcb49b135717c288335d989c6",
+      "address": "0x50f184a01e87d86e74f45106b42393bfce31f1cfc7e99585b678110774307dd",
+      "class_hash": "0x4b68cbca8f4e749e2f0e2be0e911c3d6101e0966fc4796447b48fc468cc518d",
       "abi": [
         {
           "type": "impl",
@@ -4472,12 +4773,106 @@
         },
         {
           "type": "impl",
-          "name": "RendererSystemsImpl",
-          "interface_name": "lootsurvivor::systems::renderer::contracts::IRendererSystems"
+          "name": "GameDetailsImpl",
+          "interface_name": "game_components_minigame::interface::IMinigameDetails"
+        },
+        {
+          "type": "struct",
+          "name": "game_components_minigame::structs::GameDetail",
+          "members": [
+            {
+              "name": "name",
+              "type": "core::byte_array::ByteArray"
+            },
+            {
+              "name": "value",
+              "type": "core::byte_array::ByteArray"
+            }
+          ]
+        },
+        {
+          "type": "struct",
+          "name": "core::array::Span::<game_components_minigame::structs::GameDetail>",
+          "members": [
+            {
+              "name": "snapshot",
+              "type": "@core::array::Array::<game_components_minigame::structs::GameDetail>"
+            }
+          ]
         },
         {
           "type": "interface",
-          "name": "lootsurvivor::systems::renderer::contracts::IRendererSystems",
+          "name": "game_components_minigame::interface::IMinigameDetails",
+          "items": [
+            {
+              "type": "function",
+              "name": "token_description",
+              "inputs": [
+                {
+                  "name": "token_id",
+                  "type": "core::integer::u64"
+                }
+              ],
+              "outputs": [
+                {
+                  "type": "core::byte_array::ByteArray"
+                }
+              ],
+              "state_mutability": "view"
+            },
+            {
+              "type": "function",
+              "name": "game_details",
+              "inputs": [
+                {
+                  "name": "token_id",
+                  "type": "core::integer::u64"
+                }
+              ],
+              "outputs": [
+                {
+                  "type": "core::array::Span::<game_components_minigame::structs::GameDetail>"
+                }
+              ],
+              "state_mutability": "view"
+            }
+          ]
+        },
+        {
+          "type": "impl",
+          "name": "GameDetailsSVGImpl",
+          "interface_name": "game_components_minigame::interface::IMinigameDetailsSVG"
+        },
+        {
+          "type": "interface",
+          "name": "game_components_minigame::interface::IMinigameDetailsSVG",
+          "items": [
+            {
+              "type": "function",
+              "name": "game_details_svg",
+              "inputs": [
+                {
+                  "name": "token_id",
+                  "type": "core::integer::u64"
+                }
+              ],
+              "outputs": [
+                {
+                  "type": "core::byte_array::ByteArray"
+                }
+              ],
+              "state_mutability": "view"
+            }
+          ]
+        },
+        {
+          "type": "impl",
+          "name": "RendererSystemsImpl",
+          "interface_name": "death_mountain::systems::renderer::contracts::IRendererSystems"
+        },
+        {
+          "type": "interface",
+          "name": "death_mountain::systems::renderer::contracts::IRendererSystems",
           "items": [
             {
               "type": "function",
@@ -4491,6 +4886,38 @@
               "outputs": [
                 {
                   "type": "core::byte_array::ByteArray"
+                }
+              ],
+              "state_mutability": "view"
+            },
+            {
+              "type": "function",
+              "name": "generate_svg",
+              "inputs": [
+                {
+                  "name": "adventurer_id",
+                  "type": "core::integer::u64"
+                }
+              ],
+              "outputs": [
+                {
+                  "type": "core::byte_array::ByteArray"
+                }
+              ],
+              "state_mutability": "view"
+            },
+            {
+              "type": "function",
+              "name": "generate_details",
+              "inputs": [
+                {
+                  "name": "adventurer_id",
+                  "type": "core::integer::u64"
+                }
+              ],
+              "outputs": [
+                {
+                  "type": "core::array::Span::<game_components_minigame::structs::GameDetail>"
                 }
               ],
               "state_mutability": "view"
@@ -4596,7 +5023,7 @@
         },
         {
           "type": "event",
-          "name": "lootsurvivor::systems::renderer::contracts::renderer_systems::Event",
+          "name": "death_mountain::systems::renderer::contracts::renderer_systems::Event",
           "kind": "enum",
           "variants": [
             {
@@ -4613,15 +5040,15 @@
         }
       ],
       "init_calldata": [],
-      "tag": "ls_0_0_1-renderer_systems",
-      "selector": "0x4608ae26b268d0cd477ec90404d51a3220f52cd9ef293a66cc6ac2d7609798f",
+      "tag": "ls_0_0_5-renderer_systems",
+      "selector": "0x63442767376095efb200e063d409c0df9490ba41c6bce2c65588cf27a92a809",
       "systems": [
         "upgrade"
       ]
     },
     {
-      "address": "0xefb3cd6b2d70109162ca62e57381db51424d085c930f35ac3e888be10922c2",
-      "class_hash": "0x6fe0ef13d1ba76ada3ddd907b0897c5600d4795b28d32308f50cb0e3f17569d",
+      "address": "0x512c2a8ddb6e9b4d2d4e0c7a3a7aa98022dc511589ee1be5035b863267a1496",
+      "class_hash": "0x582636c4ef6a36a3fd8189e49358192406c3c86988cc2b006d379cd211b1125",
       "abi": [
         {
           "type": "impl",
@@ -4674,13 +5101,119 @@
           ]
         },
         {
+          "type": "function",
+          "name": "dojo_init",
+          "inputs": [],
+          "outputs": [],
+          "state_mutability": "external"
+        },
+        {
           "type": "impl",
-          "name": "SettingsSystemsImpl",
-          "interface_name": "lootsurvivor::systems::settings::contracts::ISettingsSystems"
+          "name": "GameSettingsImpl",
+          "interface_name": "game_components_minigame::extensions::settings::interface::IMinigameSettings"
+        },
+        {
+          "type": "enum",
+          "name": "core::bool",
+          "variants": [
+            {
+              "name": "False",
+              "type": "()"
+            },
+            {
+              "name": "True",
+              "type": "()"
+            }
+          ]
         },
         {
           "type": "struct",
-          "name": "lootsurvivor::models::adventurer::stats::Stats",
+          "name": "game_components_minigame::extensions::settings::structs::GameSetting",
+          "members": [
+            {
+              "name": "name",
+              "type": "core::byte_array::ByteArray"
+            },
+            {
+              "name": "value",
+              "type": "core::byte_array::ByteArray"
+            }
+          ]
+        },
+        {
+          "type": "struct",
+          "name": "core::array::Span::<game_components_minigame::extensions::settings::structs::GameSetting>",
+          "members": [
+            {
+              "name": "snapshot",
+              "type": "@core::array::Array::<game_components_minigame::extensions::settings::structs::GameSetting>"
+            }
+          ]
+        },
+        {
+          "type": "struct",
+          "name": "game_components_minigame::extensions::settings::structs::GameSettingDetails",
+          "members": [
+            {
+              "name": "name",
+              "type": "core::byte_array::ByteArray"
+            },
+            {
+              "name": "description",
+              "type": "core::byte_array::ByteArray"
+            },
+            {
+              "name": "settings",
+              "type": "core::array::Span::<game_components_minigame::extensions::settings::structs::GameSetting>"
+            }
+          ]
+        },
+        {
+          "type": "interface",
+          "name": "game_components_minigame::extensions::settings::interface::IMinigameSettings",
+          "items": [
+            {
+              "type": "function",
+              "name": "settings_exist",
+              "inputs": [
+                {
+                  "name": "settings_id",
+                  "type": "core::integer::u32"
+                }
+              ],
+              "outputs": [
+                {
+                  "type": "core::bool"
+                }
+              ],
+              "state_mutability": "view"
+            },
+            {
+              "type": "function",
+              "name": "settings",
+              "inputs": [
+                {
+                  "name": "settings_id",
+                  "type": "core::integer::u32"
+                }
+              ],
+              "outputs": [
+                {
+                  "type": "game_components_minigame::extensions::settings::structs::GameSettingDetails"
+                }
+              ],
+              "state_mutability": "view"
+            }
+          ]
+        },
+        {
+          "type": "impl",
+          "name": "SettingsSystemsImpl",
+          "interface_name": "death_mountain::systems::settings::contracts::ISettingsSystems"
+        },
+        {
+          "type": "struct",
+          "name": "death_mountain::models::adventurer::stats::Stats",
           "members": [
             {
               "name": "strength",
@@ -4714,7 +5247,7 @@
         },
         {
           "type": "struct",
-          "name": "lootsurvivor::models::adventurer::item::Item",
+          "name": "death_mountain::models::adventurer::item::Item",
           "members": [
             {
               "name": "id",
@@ -4728,45 +5261,45 @@
         },
         {
           "type": "struct",
-          "name": "lootsurvivor::models::adventurer::equipment::Equipment",
+          "name": "death_mountain::models::adventurer::equipment::Equipment",
           "members": [
             {
               "name": "weapon",
-              "type": "lootsurvivor::models::adventurer::item::Item"
+              "type": "death_mountain::models::adventurer::item::Item"
             },
             {
               "name": "chest",
-              "type": "lootsurvivor::models::adventurer::item::Item"
+              "type": "death_mountain::models::adventurer::item::Item"
             },
             {
               "name": "head",
-              "type": "lootsurvivor::models::adventurer::item::Item"
+              "type": "death_mountain::models::adventurer::item::Item"
             },
             {
               "name": "waist",
-              "type": "lootsurvivor::models::adventurer::item::Item"
+              "type": "death_mountain::models::adventurer::item::Item"
             },
             {
               "name": "foot",
-              "type": "lootsurvivor::models::adventurer::item::Item"
+              "type": "death_mountain::models::adventurer::item::Item"
             },
             {
               "name": "hand",
-              "type": "lootsurvivor::models::adventurer::item::Item"
+              "type": "death_mountain::models::adventurer::item::Item"
             },
             {
               "name": "neck",
-              "type": "lootsurvivor::models::adventurer::item::Item"
+              "type": "death_mountain::models::adventurer::item::Item"
             },
             {
               "name": "ring",
-              "type": "lootsurvivor::models::adventurer::item::Item"
+              "type": "death_mountain::models::adventurer::item::Item"
             }
           ]
         },
         {
           "type": "struct",
-          "name": "lootsurvivor::models::adventurer::adventurer::Adventurer",
+          "name": "death_mountain::models::adventurer::adventurer::Adventurer",
           "members": [
             {
               "name": "health",
@@ -4790,11 +5323,11 @@
             },
             {
               "name": "stats",
-              "type": "lootsurvivor::models::adventurer::stats::Stats"
+              "type": "death_mountain::models::adventurer::stats::Stats"
             },
             {
               "name": "equipment",
-              "type": "lootsurvivor::models::adventurer::equipment::Equipment"
+              "type": "death_mountain::models::adventurer::equipment::Equipment"
             },
             {
               "name": "item_specials_seed",
@@ -4807,82 +5340,68 @@
           ]
         },
         {
-          "type": "enum",
-          "name": "core::bool",
-          "variants": [
-            {
-              "name": "False",
-              "type": "()"
-            },
-            {
-              "name": "True",
-              "type": "()"
-            }
-          ]
-        },
-        {
           "type": "struct",
-          "name": "lootsurvivor::models::adventurer::bag::Bag",
+          "name": "death_mountain::models::adventurer::bag::Bag",
           "members": [
             {
               "name": "item_1",
-              "type": "lootsurvivor::models::adventurer::item::Item"
+              "type": "death_mountain::models::adventurer::item::Item"
             },
             {
               "name": "item_2",
-              "type": "lootsurvivor::models::adventurer::item::Item"
+              "type": "death_mountain::models::adventurer::item::Item"
             },
             {
               "name": "item_3",
-              "type": "lootsurvivor::models::adventurer::item::Item"
+              "type": "death_mountain::models::adventurer::item::Item"
             },
             {
               "name": "item_4",
-              "type": "lootsurvivor::models::adventurer::item::Item"
+              "type": "death_mountain::models::adventurer::item::Item"
             },
             {
               "name": "item_5",
-              "type": "lootsurvivor::models::adventurer::item::Item"
+              "type": "death_mountain::models::adventurer::item::Item"
             },
             {
               "name": "item_6",
-              "type": "lootsurvivor::models::adventurer::item::Item"
+              "type": "death_mountain::models::adventurer::item::Item"
             },
             {
               "name": "item_7",
-              "type": "lootsurvivor::models::adventurer::item::Item"
+              "type": "death_mountain::models::adventurer::item::Item"
             },
             {
               "name": "item_8",
-              "type": "lootsurvivor::models::adventurer::item::Item"
+              "type": "death_mountain::models::adventurer::item::Item"
             },
             {
               "name": "item_9",
-              "type": "lootsurvivor::models::adventurer::item::Item"
+              "type": "death_mountain::models::adventurer::item::Item"
             },
             {
               "name": "item_10",
-              "type": "lootsurvivor::models::adventurer::item::Item"
+              "type": "death_mountain::models::adventurer::item::Item"
             },
             {
               "name": "item_11",
-              "type": "lootsurvivor::models::adventurer::item::Item"
+              "type": "death_mountain::models::adventurer::item::Item"
             },
             {
               "name": "item_12",
-              "type": "lootsurvivor::models::adventurer::item::Item"
+              "type": "death_mountain::models::adventurer::item::Item"
             },
             {
               "name": "item_13",
-              "type": "lootsurvivor::models::adventurer::item::Item"
+              "type": "death_mountain::models::adventurer::item::Item"
             },
             {
               "name": "item_14",
-              "type": "lootsurvivor::models::adventurer::item::Item"
+              "type": "death_mountain::models::adventurer::item::Item"
             },
             {
               "name": "item_15",
-              "type": "lootsurvivor::models::adventurer::item::Item"
+              "type": "death_mountain::models::adventurer::item::Item"
             },
             {
               "name": "mutated",
@@ -4891,20 +5410,38 @@
           ]
         },
         {
+          "type": "enum",
+          "name": "death_mountain::models::game::StatsMode",
+          "variants": [
+            {
+              "name": "Dodge",
+              "type": "()"
+            },
+            {
+              "name": "Reduction",
+              "type": "()"
+            }
+          ]
+        },
+        {
           "type": "struct",
-          "name": "lootsurvivor::models::game::GameSettings",
+          "name": "death_mountain::models::game::GameSettings",
           "members": [
             {
               "name": "settings_id",
               "type": "core::integer::u32"
             },
             {
+              "name": "vrf_address",
+              "type": "core::starknet::contract_address::ContractAddress"
+            },
+            {
               "name": "adventurer",
-              "type": "lootsurvivor::models::adventurer::adventurer::Adventurer"
+              "type": "death_mountain::models::adventurer::adventurer::Adventurer"
             },
             {
               "name": "bag",
-              "type": "lootsurvivor::models::adventurer::bag::Bag"
+              "type": "death_mountain::models::adventurer::bag::Bag"
             },
             {
               "name": "game_seed",
@@ -4917,28 +5454,48 @@
             {
               "name": "in_battle",
               "type": "core::bool"
+            },
+            {
+              "name": "stats_mode",
+              "type": "death_mountain::models::game::StatsMode"
+            },
+            {
+              "name": "base_damage_reduction",
+              "type": "core::integer::u8"
+            },
+            {
+              "name": "market_size",
+              "type": "core::integer::u8"
             }
           ]
         },
         {
           "type": "interface",
-          "name": "lootsurvivor::systems::settings::contracts::ISettingsSystems",
+          "name": "death_mountain::systems::settings::contracts::ISettingsSystems",
           "items": [
             {
               "type": "function",
               "name": "add_settings",
               "inputs": [
                 {
+                  "name": "vrf_address",
+                  "type": "core::starknet::contract_address::ContractAddress"
+                },
+                {
                   "name": "name",
                   "type": "core::felt252"
                 },
                 {
+                  "name": "description",
+                  "type": "core::byte_array::ByteArray"
+                },
+                {
                   "name": "adventurer",
-                  "type": "lootsurvivor::models::adventurer::adventurer::Adventurer"
+                  "type": "death_mountain::models::adventurer::adventurer::Adventurer"
                 },
                 {
                   "name": "bag",
-                  "type": "lootsurvivor::models::adventurer::bag::Bag"
+                  "type": "death_mountain::models::adventurer::bag::Bag"
                 },
                 {
                   "name": "game_seed",
@@ -4951,6 +5508,18 @@
                 {
                   "name": "in_battle",
                   "type": "core::bool"
+                },
+                {
+                  "name": "stats_mode",
+                  "type": "death_mountain::models::game::StatsMode"
+                },
+                {
+                  "name": "base_damage_reduction",
+                  "type": "core::integer::u8"
+                },
+                {
+                  "name": "market_size",
+                  "type": "core::integer::u8"
                 }
               ],
               "outputs": [
@@ -4971,7 +5540,7 @@
               ],
               "outputs": [
                 {
-                  "type": "lootsurvivor::models::game::GameSettings"
+                  "type": "death_mountain::models::game::GameSettings"
                 }
               ],
               "state_mutability": "view"
@@ -4987,7 +5556,7 @@
               ],
               "outputs": [
                 {
-                  "type": "lootsurvivor::models::game::GameSettings"
+                  "type": "death_mountain::models::game::GameSettings"
                 }
               ],
               "state_mutability": "view"
@@ -5004,13 +5573,6 @@
               "state_mutability": "view"
             }
           ]
-        },
-        {
-          "type": "function",
-          "name": "dojo_init",
-          "inputs": [],
-          "outputs": [],
-          "state_mutability": "view"
         },
         {
           "type": "impl",
@@ -5068,6 +5630,33 @@
           ]
         },
         {
+          "type": "impl",
+          "name": "SRC5Impl",
+          "interface_name": "openzeppelin_introspection::interface::ISRC5"
+        },
+        {
+          "type": "interface",
+          "name": "openzeppelin_introspection::interface::ISRC5",
+          "items": [
+            {
+              "type": "function",
+              "name": "supports_interface",
+              "inputs": [
+                {
+                  "name": "interface_id",
+                  "type": "core::felt252"
+                }
+              ],
+              "outputs": [
+                {
+                  "type": "core::bool"
+                }
+              ],
+              "state_mutability": "view"
+            }
+          ]
+        },
+        {
           "type": "constructor",
           "name": "constructor",
           "inputs": []
@@ -5104,7 +5693,19 @@
         },
         {
           "type": "event",
-          "name": "lootsurvivor::systems::settings::contracts::settings_systems::Event",
+          "name": "game_components_minigame::extensions::settings::settings::SettingsComponent::Event",
+          "kind": "enum",
+          "variants": []
+        },
+        {
+          "type": "event",
+          "name": "openzeppelin_introspection::src5::SRC5Component::Event",
+          "kind": "enum",
+          "variants": []
+        },
+        {
+          "type": "event",
+          "name": "death_mountain::systems::settings::contracts::settings_systems::Event",
           "kind": "enum",
           "variants": [
             {
@@ -5116,14 +5717,25 @@
               "name": "WorldProviderEvent",
               "type": "dojo::contract::components::world_provider::world_provider_cpt::Event",
               "kind": "nested"
+            },
+            {
+              "name": "SettingsEvent",
+              "type": "game_components_minigame::extensions::settings::settings::SettingsComponent::Event",
+              "kind": "flat"
+            },
+            {
+              "name": "SRC5Event",
+              "type": "openzeppelin_introspection::src5::SRC5Component::Event",
+              "kind": "flat"
             }
           ]
         }
       ],
       "init_calldata": [],
-      "tag": "ls_0_0_1-settings_systems",
-      "selector": "0x66bb04604f81385856aa7b8526ccdaeeb6bf1568e3656e1eea1727d41d2f206",
+      "tag": "ls_0_0_5-settings_systems",
+      "selector": "0x445e9e22a3d6100fa49205e08c0f7ecb4faf2d3264f0ffc034ba2ca23ba4eb2",
       "systems": [
+        "dojo_init",
         "add_settings",
         "upgrade"
       ]
@@ -5133,83 +5745,89 @@
   "models": [
     {
       "members": [],
-      "class_hash": "0x36e073f57e35772e2b59f74a37fafbcc004d7d9e7b41646d43d0c12ea049ba3",
-      "tag": "ls_0_0_1-AdventurerEntropy",
-      "selector": "0x369ce532fa31b6549abc44fb7a6d333084daf0978c7b5e95ca78407fef17453"
+      "class_hash": "0x771a18fa631c8bf12e2b85cdf510b9b59959655090027883b18100641a08497",
+      "tag": "ls_0_0_5-AdventurerEntropy",
+      "selector": "0x4e0ea8620e0cfb76e65e15dabca6a154d41cb9e5dce590c1cb942920ac8e500"
     },
     {
       "members": [],
-      "class_hash": "0x4dfc271be295406f7da99e8e76f16d12abf77f5d477c80fdc261f80e02b4237",
-      "tag": "ls_0_0_1-AdventurerPacked",
-      "selector": "0xa5c361de35b1a9acbabf8dd9eead845c7302c15602ce4be7b221568434f2b3"
+      "class_hash": "0x7271344d76037ef2c0e6e8156b7dfa7c7b40dfc566b99f9770c99b14cb70e5b",
+      "tag": "ls_0_0_5-AdventurerKilled",
+      "selector": "0x16c5555af92a4eafb1f010711d8ad96e92d6d385e494ec6aebcb7a9af7b69a3"
     },
     {
       "members": [],
-      "class_hash": "0x48c6db8ac242ce05f2d747797de4d00e533c8b82f2213bc7374543e481f7578",
-      "tag": "ls_0_0_1-BagPacked",
-      "selector": "0x2775a303d6e4b7050633a53726b7f0b470d335dcd09a10a265d5c4ba453767e"
+      "class_hash": "0x33b8218ffef53844194e5bc510edfa023441c8284a0254b002742509af88449",
+      "tag": "ls_0_0_5-AdventurerPacked",
+      "selector": "0xd218787f47741c532120b495ece65e32fdd00dbcaa86e12c111e9d72a05e56"
     },
     {
       "members": [],
-      "class_hash": "0x4c9aa5cf3f03bd208fcfc809bbefd59074e319870fd54e699df593d2df01b4d",
-      "tag": "ls_0_0_1-GameCounter",
-      "selector": "0xf9d664d45cf0ce7f86c2ff1313ba577752a416b01d4f3902597609f7cf5d3"
+      "class_hash": "0x283ab5cc1ee44d8476f367faf47184901b144bfbc36740491a5a96dbb950599",
+      "tag": "ls_0_0_5-BagPacked",
+      "selector": "0x9b4f5d85571e8dc91b3625c448df17717f7e69fba4982e821a38938e51c898"
     },
     {
       "members": [],
-      "class_hash": "0x2184a8d33905eed66c3a80bd753a579aadd0b8dd0652f9f513dc7f1949f53c4",
-      "tag": "ls_0_0_1-GameMetadata",
-      "selector": "0x4e75ab55ed734711b399c7fc6dd5311dc051b565d5f383e5f2f690a9a0c8f82"
+      "class_hash": "0x3f58ca824d6b406472a58004a59fedc42889bb3b46220766b10e4e2f004e5b6",
+      "tag": "ls_0_0_5-CollectableCount",
+      "selector": "0x7bad0b29da2a18fef41ed4871e85cdbd051185b9d8aef8baa82ca96957ab01d"
     },
     {
       "members": [],
-      "class_hash": "0x35e166c888f48fda40e84274c0fadd91a3a914a29c320461189fa045c1d62ad",
-      "tag": "ls_0_0_1-GameSettings",
-      "selector": "0x2b4e78e32ea8503f2dc7123211b672ce9712a014664c3a4d955eefda8371ab6"
+      "class_hash": "0x603d0d6568096654bbabaa2f1494a497f3060fa3c03882823cea468c8b9bf94",
+      "tag": "ls_0_0_5-CollectableEntity",
+      "selector": "0x73482c675d080bac6d6ac51ffe2dfb50c875281fbe83fa0ac66be5df93e23cc"
     },
     {
       "members": [],
-      "class_hash": "0x303efd2717ebe9fbb6425471d4955026a55ec39522f7580f3648d63d88a7409",
-      "tag": "ls_0_0_1-GameSettingsMetadata",
-      "selector": "0x625c0bd4f129262bf06ae31dce0790db319e6dc1ebf8b6a7f996dccfd27a03b"
+      "class_hash": "0x1574c394faebc84b15fd5e43414a47ac257ebadb3683775d4df7998bdfdc840",
+      "tag": "ls_0_0_5-DroppedItem",
+      "selector": "0x706cd23a322dca735ff16f9bf339f8f3412a822a4da7534edb38f109c410d57"
     },
     {
       "members": [],
-      "class_hash": "0x7538cc093e191e767f1caf8ea3f1c4818e319db41d8f760e48753cb2e420156",
-      "tag": "ls_0_0_1-Score",
-      "selector": "0x17768bbe9b110e47f39164d7c6cbc2be5e8a146a4a6d321e3f36877c5b62e1d"
+      "class_hash": "0x654e3dcfe40ee0d8a3e2d17a448f8208a2515316b9573629ef9ebb038ae2fda",
+      "tag": "ls_0_0_5-EntityStats",
+      "selector": "0x27f5cd07772517d4fd6433e0e8bb1b95c119bc3d47ad060516dd5e52d59c11d"
     },
     {
       "members": [],
-      "class_hash": "0x1209baf4f84faefa02c38ae721ddc691755ff4ea5993861fa22d822c913ab5b",
-      "tag": "ls_0_0_1-Settings",
-      "selector": "0x65aea8914867efd68abcd493ef62cd558714808a78da321c26cfb239691c15a"
+      "class_hash": "0x60334ed79ffe3bb44f5331aa432014a9df104683769da7a4ad6dab9e23630fb",
+      "tag": "ls_0_0_5-GameSettings",
+      "selector": "0x207a8c2a70cd16fa38f2a3e019b16a441e18d017147bc5061f4192f4e4c1f25"
     },
     {
       "members": [],
-      "class_hash": "0x4e0c7a60762ca47580e47d2d2dcb27dd5ad33262075cb9b126d670e97c67837",
-      "tag": "ls_0_0_1-SettingsCounter",
-      "selector": "0x4ce54354ad90c2baef50e7f5db05727087d6565f8522dbeb36d2e5893ef06da"
+      "class_hash": "0x42467a73ead2a48a5d522d48d5ca6fa81a6a5b1377b6b8f0e32c3b0f4c0c8b6",
+      "tag": "ls_0_0_5-GameSettingsMetadata",
+      "selector": "0x5ae772d27011510ec2ed5df181c7e368c5ee662cf52d8408d1b6b00d28d6e17"
     },
     {
       "members": [],
-      "class_hash": "0x5a1e9671225dd42b4085d3fb27a7543ee87f0cb687514002e7b4d9fa77c78a1",
-      "tag": "ls_0_0_1-SettingsDetails",
-      "selector": "0x434abaa931311266f75d76fdfaa250fb42fb549b1b04a1c015009ddfd90132"
+      "class_hash": "0x2aa835e634c1a8ff12a13e1f1e8592a1f9efcfb61f048e8907a7b4e29656930",
+      "tag": "ls_0_0_5-ScoreObjective",
+      "selector": "0x325fddc6889b22ed2aeb58e663a880ada247603054e6eb789937a5e30023a41"
     },
     {
       "members": [],
-      "class_hash": "0x336f9d3953c032d579de6675aa25e2903ea50708399ca5ec3312ee3480e7cca",
-      "tag": "ls_0_0_1-TokenMetadata",
-      "selector": "0x544af3859f7a1b523d0b5fac02a2f7b424a1fd6f145470fdca7003a637e28cb"
+      "class_hash": "0x5ece982bfe94084959dcedbf5a4474810aeeef714cc4bb2ef78248aa36dd9e4",
+      "tag": "ls_0_0_5-ScoreObjectiveCount",
+      "selector": "0x4cfce6f8428f0a737588196b317066191ee452c87cb1badb5f3931cf31ed109"
+    },
+    {
+      "members": [],
+      "class_hash": "0x791787e562ed970a599a13e2f690391968b8f75ea0dcfc38573fc3300c6c942",
+      "tag": "ls_0_0_5-SettingsCounter",
+      "selector": "0x66a540b94018310930eab07bf970cd425e484c867680d47b84d0a19e4a6ab15"
     }
   ],
   "events": [
     {
       "members": [],
-      "class_hash": "0x6c6269784fff73e18c54bf400d8062294ed8be1d17e4abcd28f7a68be4e2f4b",
-      "tag": "ls_0_0_1-GameEvent",
-      "selector": "0x26d8912eece420b95692b8da8105587d09888bd0ff0e243c8e8cfb0e23ab894"
+      "class_hash": "0x5a3ab3a85b1c39cf5678ef7247fbec098103c4baf9f52d41632d22acce4e77d",
+      "tag": "ls_0_0_5-GameEvent",
+      "selector": "0x538414346e04c62c9ac7bdf4279d2e8b02e9133f5ae1959e7a467556e593f5e"
     }
   ],
   "external_contracts": []

--- a/client/manifest_sepolia.json
+++ b/client/manifest_sepolia.json
@@ -1,7 +1,7 @@
 {
   "world": {
     "class_hash": "0x685ed02eefa98fe7e208aa295042e9bbad8029b0d3d6f0ba2b32546efe0a1f9",
-    "address": "0x38f6eb0186dfd1e072fa3b289b88e1c67b0baf1bd76cc6987f4a93258c69c4d",
+    "address": "0x3640d513d1d398f3221adcc7b038fcd3a875e85cce31014897337b7f0d0be6e",
     "seed": "DNC",
     "name": "Provable Games",
     "entrypoints": [
@@ -1328,7 +1328,7 @@
   },
   "contracts": [
     {
-      "address": "0x7cb86dc3a492d4e2db3afee800d9481ab862c67fc15f98bab4817de8370f2f7",
+      "address": "0x61f4d906946b1000a075110590f41abde04bc7cd40b2562c8684e42428b4427",
       "class_hash": "0x5acc9993f40b542e4fc167a5ace9047dc2776fc36f1a07b966e0142388a0edb",
       "abi": [
         {
@@ -2442,7 +2442,7 @@
       ]
     },
     {
-      "address": "0x324d04ce74e00989db72d7fed1d2efd659f8b8f7f227050a7971e187ffc2f7",
+      "address": "0x577a012c28c1dc01e9ac4a2c56a38d03913f66a083f04c569aaec193564d8d1",
       "class_hash": "0x7406e9437f9b405c8152eb138b61818e66ce4f8a7526a22902e6fe631c75566",
       "abi": [
         {
@@ -3152,8 +3152,8 @@
       ]
     },
     {
-      "address": "0x39d9adb951d94086d6a25d430a58391c7951f2e1e5fa37db0394a5a256002a7",
-      "class_hash": "0x70cf2ee3812c7d78b2fa1efff497376927b1d6b41d4124a2abbf1e8508d0184",
+      "address": "0x3554d442963d196e4ea7d66ebc9232c8cb7d851288d0850b6197d5844f1c59f",
+      "class_hash": "0x56cd9da765d0bf4342c6d2ddd14716cdbae39ff701987f40e0f04dd40f15b70",
       "abi": [
         {
           "type": "impl",
@@ -3541,7 +3541,7 @@
       ]
     },
     {
-      "address": "0x5111300a337dfb892fda7e594a80c229f239caf0f337dc864b681b9a77555b7",
+      "address": "0x51f93d0200780270f0ca791eb36700d8aaf1c888da0635ec7abcc897e32aff3",
       "class_hash": "0x54fbd3cc638c4ba0ba84d4101ae88e03c89e6998badd412f3c7eff45d106814",
       "abi": [
         {
@@ -4199,7 +4199,7 @@
       ],
       "init_calldata": [
         "0x065d2AB17338b5AffdEbAF95E2D79834B5f30Bac596fF55563c62C3c98700150",
-        "0x01fd7f186c0bb99f8d128f1eb40dbe3c7657df381957417f8c9a40804c005545"
+        "0x05e0f818f368a6bc04e923541477181d6e47044549fc6f4eb0fb4c8d7da373a9"
       ],
       "tag": "ls_0_0_5-game_token_systems",
       "selector": "0x56361f0ad3f6ec1de7434cf73b2338cbd47a310909ba2d7a0df86640b561982",
@@ -4211,7 +4211,7 @@
       ]
     },
     {
-      "address": "0x301e2400c9eb8c84c576506c890721537ca0960a73c75d42943a0965aa789ae",
+      "address": "0x5a29a56d2c898daaff58c7c3bdaabb1e94da53f5a08fddd87ea69c596f80bad",
       "class_hash": "0x23cdb494302994de197966707c72df5708f2516f5205ed398dacb4c16fc4bcc",
       "abi": [
         {
@@ -4718,7 +4718,7 @@
       ]
     },
     {
-      "address": "0x50f184a01e87d86e74f45106b42393bfce31f1cfc7e99585b678110774307dd",
+      "address": "0x7d1b268d3005104cda0bd09b9c2d091d4de8485951319f27785939b4ddcd490",
       "class_hash": "0x4b68cbca8f4e749e2f0e2be0e911c3d6101e0966fc4796447b48fc468cc518d",
       "abi": [
         {
@@ -5047,8 +5047,8 @@
       ]
     },
     {
-      "address": "0x512c2a8ddb6e9b4d2d4e0c7a3a7aa98022dc511589ee1be5035b863267a1496",
-      "class_hash": "0x582636c4ef6a36a3fd8189e49358192406c3c86988cc2b006d379cd211b1125",
+      "address": "0x746c0e710592726b5e933ebcbcc8b1f006ca6a9024608d0c1788f7841f24df8",
+      "class_hash": "0x6422f872b8709ab4736e950bf6a85d093f9a4868d14fe33677912e2ee957813",
       "abi": [
         {
           "type": "impl",

--- a/client/manifest_sepolia.json
+++ b/client/manifest_sepolia.json
@@ -1,7 +1,7 @@
 {
   "world": {
     "class_hash": "0x685ed02eefa98fe7e208aa295042e9bbad8029b0d3d6f0ba2b32546efe0a1f9",
-    "address": "0x3640d513d1d398f3221adcc7b038fcd3a875e85cce31014897337b7f0d0be6e",
+    "address": "0x29f11cefb67df8a3962ba60816800ccf196f9497ae781bb4bc8589f8e245753",
     "seed": "DNC",
     "name": "Provable Games",
     "entrypoints": [
@@ -1328,7 +1328,7 @@
   },
   "contracts": [
     {
-      "address": "0x61f4d906946b1000a075110590f41abde04bc7cd40b2562c8684e42428b4427",
+      "address": "0x20fd21d6bfce809959f266e427244ebc4e6470fb41324608cab460085245c72",
       "class_hash": "0x5acc9993f40b542e4fc167a5ace9047dc2776fc36f1a07b966e0142388a0edb",
       "abi": [
         {
@@ -2442,7 +2442,7 @@
       ]
     },
     {
-      "address": "0x577a012c28c1dc01e9ac4a2c56a38d03913f66a083f04c569aaec193564d8d1",
+      "address": "0x53436827646567f4a6137ac91f7603ee98a52eacda32fe59c601a48344fb4d0",
       "class_hash": "0x7406e9437f9b405c8152eb138b61818e66ce4f8a7526a22902e6fe631c75566",
       "abi": [
         {
@@ -3152,7 +3152,7 @@
       ]
     },
     {
-      "address": "0x3554d442963d196e4ea7d66ebc9232c8cb7d851288d0850b6197d5844f1c59f",
+      "address": "0x89e0eccd76c3a7acc221f008ce5eff5fb067e86c1a37be06d2ff201ee4cd4a",
       "class_hash": "0x56cd9da765d0bf4342c6d2ddd14716cdbae39ff701987f40e0f04dd40f15b70",
       "abi": [
         {
@@ -3541,7 +3541,7 @@
       ]
     },
     {
-      "address": "0x51f93d0200780270f0ca791eb36700d8aaf1c888da0635ec7abcc897e32aff3",
+      "address": "0x5eecb8d59907fb3bbc44a6618e4f5b7a7d9e8dcfcb8eaa7d64dd32ef8260aaf",
       "class_hash": "0x54fbd3cc638c4ba0ba84d4101ae88e03c89e6998badd412f3c7eff45d106814",
       "abi": [
         {
@@ -4199,7 +4199,7 @@
       ],
       "init_calldata": [
         "0x065d2AB17338b5AffdEbAF95E2D79834B5f30Bac596fF55563c62C3c98700150",
-        "0x05e0f818f368a6bc04e923541477181d6e47044549fc6f4eb0fb4c8d7da373a9"
+        "0x06a1102ed881e0d6d689295db5819dd1d15f0d55cbe10e1b87587c2ea1ec8da4"
       ],
       "tag": "ls_0_0_5-game_token_systems",
       "selector": "0x56361f0ad3f6ec1de7434cf73b2338cbd47a310909ba2d7a0df86640b561982",
@@ -4211,7 +4211,7 @@
       ]
     },
     {
-      "address": "0x5a29a56d2c898daaff58c7c3bdaabb1e94da53f5a08fddd87ea69c596f80bad",
+      "address": "0x775b72184867dc97ecd399c1dfec3d60822408f352b8ff4ccb3d967a400f07e",
       "class_hash": "0x23cdb494302994de197966707c72df5708f2516f5205ed398dacb4c16fc4bcc",
       "abi": [
         {
@@ -4718,7 +4718,7 @@
       ]
     },
     {
-      "address": "0x7d1b268d3005104cda0bd09b9c2d091d4de8485951319f27785939b4ddcd490",
+      "address": "0x1776642194d3b29859e6e309314ac6e4888ba56d67954b9d6e5db65e4427650",
       "class_hash": "0x4b68cbca8f4e749e2f0e2be0e911c3d6101e0966fc4796447b48fc468cc518d",
       "abi": [
         {
@@ -5047,7 +5047,7 @@
       ]
     },
     {
-      "address": "0x746c0e710592726b5e933ebcbcc8b1f006ca6a9024608d0c1788f7841f24df8",
+      "address": "0x3b8c69c6e3c405ec645bf977aca95b2d2978fe50632806ce4c2f4ce38aa5797",
       "class_hash": "0x6422f872b8709ab4736e950bf6a85d093f9a4868d14fe33677912e2ee957813",
       "abi": [
         {

--- a/client/package.json
+++ b/client/package.json
@@ -11,8 +11,8 @@
     "serve": "vite preview"
   },
   "dependencies": {
-    "@cartridge/connector": "^0.9.1",
-    "@cartridge/controller": "^0.9.1",
+    "@cartridge/connector": "^0.9.2",
+    "@cartridge/controller": "^0.9.2",
     "@cloudflare/stream-react": "^1.9.3",
     "@dojoengine/core": "^1.6.0-beta.4",
     "@dojoengine/create-burner": "^1.6.0-beta.4",

--- a/client/pnpm-lock.yaml
+++ b/client/pnpm-lock.yaml
@@ -9,11 +9,11 @@ importers:
   .:
     dependencies:
       '@cartridge/connector':
-        specifier: ^0.9.1
-        version: 0.9.1(@metamask/sdk@0.32.1(bufferutil@4.0.9)(encoding@0.1.13)(utf-8-validate@5.0.10))(@solana/web3.js@1.98.2(bufferutil@4.0.9)(encoding@0.1.13)(typescript@5.8.3)(utf-8-validate@5.0.10))(@starknet-react/core@4.0.1-beta.4(bufferutil@4.0.9)(get-starknet-core@4.0.0)(react@18.3.1)(starknet@7.6.4)(typescript@5.8.3)(utf-8-validate@5.0.10))(@types/react@18.3.23)(bufferutil@4.0.9)(encoding@0.1.13)(open@10.2.0)(react@18.3.1)(starknet@7.6.4)(starknetkit@2.12.1(7527e31a67a40c689e60e5c9888af2ed))(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+        specifier: ^0.9.2
+        version: 0.9.2(@metamask/sdk@0.32.1(bufferutil@4.0.9)(encoding@0.1.13)(utf-8-validate@5.0.10))(@solana/web3.js@1.98.2(bufferutil@4.0.9)(encoding@0.1.13)(typescript@5.8.3)(utf-8-validate@5.0.10))(@starknet-react/core@4.0.1-beta.4(bufferutil@4.0.9)(get-starknet-core@4.0.0)(react@18.3.1)(starknet@7.6.4)(typescript@5.8.3)(utf-8-validate@5.0.10))(@types/react@18.3.23)(bufferutil@4.0.9)(encoding@0.1.13)(open@10.2.0)(react@18.3.1)(starknet@7.6.4)(starknetkit@2.12.1(7527e31a67a40c689e60e5c9888af2ed))(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.76)
       '@cartridge/controller':
-        specifier: ^0.9.1
-        version: 0.9.1(@metamask/sdk@0.32.1(bufferutil@4.0.9)(encoding@0.1.13)(utf-8-validate@5.0.10))(@solana/web3.js@1.98.2(bufferutil@4.0.9)(encoding@0.1.13)(typescript@5.8.3)(utf-8-validate@5.0.10))(@types/react@18.3.23)(bufferutil@4.0.9)(encoding@0.1.13)(open@10.2.0)(react@18.3.1)(starknet@7.6.4)(starknetkit@2.12.1(7527e31a67a40c689e60e5c9888af2ed))(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+        specifier: ^0.9.2
+        version: 0.9.2(@metamask/sdk@0.32.1(bufferutil@4.0.9)(encoding@0.1.13)(utf-8-validate@5.0.10))(@solana/web3.js@1.98.2(bufferutil@4.0.9)(encoding@0.1.13)(typescript@5.8.3)(utf-8-validate@5.0.10))(@types/react@18.3.23)(bufferutil@4.0.9)(encoding@0.1.13)(open@10.2.0)(react@18.3.1)(starknet@7.6.4)(starknetkit@2.12.1(7527e31a67a40c689e60e5c9888af2ed))(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.76)
       '@cloudflare/stream-react':
         specifier: ^1.9.3
         version: 1.9.3(react@18.3.1)
@@ -127,10 +127,10 @@ importers:
         version: 10.0.0
       vite-plugin-mkcert:
         specifier: ^1.17.8
-        version: 1.17.8(vite@5.4.19(@types/node@24.0.15)(terser@5.43.1))
+        version: 1.17.8(vite@5.4.19(@types/node@24.2.0)(terser@5.43.1))
       vite-plugin-wasm:
         specifier: ^3.4.1
-        version: 3.5.0(vite@5.4.19(@types/node@24.0.15)(terser@5.43.1))
+        version: 3.5.0(vite@5.4.19(@types/node@24.2.0)(terser@5.43.1))
     devDependencies:
       '@types/react':
         specifier: ^18.2.0
@@ -143,7 +143,7 @@ importers:
         version: 1.6.4
       '@vitejs/plugin-react':
         specifier: ^4.3.4
-        version: 4.7.0(vite@5.4.19(@types/node@24.0.15)(terser@5.43.1))
+        version: 4.7.0(vite@5.4.19(@types/node@24.2.0)(terser@5.43.1))
       eslint:
         specifier: ^9.24.0
         version: 9.31.0
@@ -161,10 +161,10 @@ importers:
         version: 8.37.0(eslint@9.31.0)(typescript@5.8.3)
       vite:
         specifier: ^5.4.18
-        version: 5.4.19(@types/node@24.0.15)(terser@5.43.1)
+        version: 5.4.19(@types/node@24.2.0)(terser@5.43.1)
       vite-plugin-top-level-await:
         specifier: ^1.5.0
-        version: 1.6.0(@swc/helpers@0.5.17)(rollup@4.45.1)(vite@5.4.19(@types/node@24.0.15)(terser@5.43.1))
+        version: 1.6.0(@swc/helpers@0.5.17)(rollup@4.45.1)(vite@5.4.19(@types/node@24.2.0)(terser@5.43.1))
       zustand:
         specifier: ^4.5.6
         version: 4.5.7(@types/react@18.3.23)(immer@10.1.1)(react@18.3.1)
@@ -387,6 +387,10 @@ packages:
     resolution: {integrity: sha512-vbavdySgbTTrmFE+EsiqUTzlOr5bzlnJtUv9PynGCAKvfQqjIXbvFdumPM/GxMDfyuGMJaJAU6TO4zc1Jf1i8Q==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/runtime@7.28.2':
+    resolution: {integrity: sha512-KHp2IflsnGywDjBWDkR9iEqiWSpc8GIi0lgTT3mOElT0PP1tG26P4tmFI2YvAdzgq9RGyoHZQEIEdZy6Ec5xCA==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/template@7.27.2':
     resolution: {integrity: sha512-LPDZ85aEJyYSd18/DkjNh4/y1ntkE5KwUHWTiqgRxruuZL2F1yuHligVHLvcHY2vMHXttKFpJn6LwfI7cw7ODw==}
     engines: {node: '>=6.9.0'}
@@ -399,16 +403,20 @@ packages:
     resolution: {integrity: sha512-x0LvFTekgSX+83TI28Y9wYPUfzrnl2aT5+5QLnO6v7mSJYtEEevuDRN0F0uSHRk1G1IWZC43o00Y0xDDrpBGPQ==}
     engines: {node: '>=6.9.0'}
 
-  '@cartridge/connector@0.9.1':
-    resolution: {integrity: sha512-+dQsxgVdZa3twq8zIfmAwEkE/Hme3XClO7WKH24jV1fTubhJaaYxZsa11iDCKPZ+ZIUKv15g4kBO/alpfxaZeA==}
+  '@babel/types@7.28.2':
+    resolution: {integrity: sha512-ruv7Ae4J5dUYULmeXw1gmb7rYRz57OWCPM57pHojnLq/3Z1CK2lNSLTCVjxVk1F/TZHwOZZrOWi0ur95BbLxNQ==}
+    engines: {node: '>=6.9.0'}
+
+  '@cartridge/connector@0.9.2':
+    resolution: {integrity: sha512-EL/EjhRTRNDJ+Mx1pnvgZO/9/e/1xeANmo5vWBd34+xN1rPSZv6p7gkyyH8MGPXh7vS9rCfuSEhJxTDx1Uldpg==}
     peerDependencies:
       '@starknet-react/core': 4.0.1-beta.4
 
   '@cartridge/controller-wasm@0.2.3':
     resolution: {integrity: sha512-2yxPMcgwdxtwy6g8VtJU6CNOAYJaSc0G5JXxcHsVeYc0rrDExk0IR1srjxhzLglYlF3jutirt9yV3mKV1NquVQ==}
 
-  '@cartridge/controller@0.9.1':
-    resolution: {integrity: sha512-T1pBOK6BGZba3Zh6xKoux7B5Q69syBJzp14l4wh1vROqM1AESbheyJKjWCKCauwV3afsC6RneuRW9+wA2avrtw==}
+  '@cartridge/controller@0.9.2':
+    resolution: {integrity: sha512-bfU0U3/M3idpEllysZckxhLU/9PdslvNW3JrBcsDFZcfm7lko7LQv1dStGHmA/7hzZdPCrrUYIGRimOBzYBbrQ==}
     peerDependencies:
       '@metamask/sdk': ^0.32.1
       '@solana/web3.js': ^1.98.0
@@ -1764,6 +1772,9 @@ packages:
   '@types/babel__traverse@7.20.7':
     resolution: {integrity: sha512-dkO5fhS7+/oos4ciWxyEyjWe48zmG6wbCheo/G2ZnHx4fs3EU6YC6UM8rk56gAjNJ9P3MTH2jo5jb92/K6wbng==}
 
+  '@types/babel__traverse@7.28.0':
+    resolution: {integrity: sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==}
+
   '@types/connect@3.4.38':
     resolution: {integrity: sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==}
 
@@ -1832,6 +1843,9 @@ packages:
 
   '@types/node@24.0.15':
     resolution: {integrity: sha512-oaeTSbCef7U/z7rDeJA138xpG3NuKc64/rZ2qmUFkFJmnMsAPaluIifqyWd8hSSMxyP9oie3dLAqYPblag9KgA==}
+
+  '@types/node@24.2.0':
+    resolution: {integrity: sha512-3xyG3pMCq3oYCNg7/ZP+E1ooTaGB4cG8JWRsqqOYQdbWNY4zbaV0Ennrd7stjiJEFZCaybcIgpTjJWHRfBSIDw==}
 
   '@types/parse-json@4.0.2':
     resolution: {integrity: sha512-dISoDXWWQwUquiKsyZ4Ng+HX2KsPL7LyHKHQwgGFEA3IaKac4Obd+h2a/a6waisAoepJlBcx9paWqjA8/HVjCw==}
@@ -2213,10 +2227,10 @@ packages:
   babel-plugin-syntax-hermes-parser@0.28.1:
     resolution: {integrity: sha512-meT17DOuUElMNsL5LZN56d+KBp22hb0EfxWfuPUeoSi54e40v1W4C2V36P75FpsH9fVEfDKpw5Nnkahc8haSsQ==}
 
-  babel-preset-current-node-syntax@1.1.0:
-    resolution: {integrity: sha512-ldYss8SbBlWva1bs28q78Ju5Zq1F+8BrqBZZ0VFhLBvhh6lCpC2o3gDJi/5DRLs9FgYZCnmPYIVFU4lRXCkyUw==}
+  babel-preset-current-node-syntax@1.2.0:
+    resolution: {integrity: sha512-E/VlAEzRrsLEb2+dv8yp3bo4scof3l9nR4lrld+Iy5NyVqgVYUJnDAmunkhPMisRI32Qc4iRiz425d8vM++2fg==}
     peerDependencies:
-      '@babel/core': ^7.0.0
+      '@babel/core': ^7.0.0 || ^8.0.0-0
 
   babel-preset-jest@29.6.3:
     resolution: {integrity: sha512-0B3bhxR6snWXJZtR/RliHTDPRgn1sNHOR0yVtq/IiQFyuOVjFS+wuio/R4gSNkyYmKmJB4wGZv2NZanmKmTnNA==}
@@ -4590,6 +4604,9 @@ packages:
   undici-types@6.19.8:
     resolution: {integrity: sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==}
 
+  undici-types@7.10.0:
+    resolution: {integrity: sha512-t5Fy/nfn+14LuOc2KNYg75vZqClpAiqscVvMygNnlsHBFpSXdJaYtXMcdNLpl/Qvc3P2cB3s6lOV51nqsFq4ag==}
+
   undici-types@7.8.0:
     resolution: {integrity: sha512-9UJ2xGDvQ43tYyVMpuHlsgApydB8ZKfVYTsLDhXkFL/6gfkp+U8xTGdh8pMJv1SpZna0zxG1DwsKZsreLbXBxw==}
 
@@ -5044,8 +5061,8 @@ packages:
       react:
         optional: true
 
-  zustand@5.0.6:
-    resolution: {integrity: sha512-ihAqNeUVhe0MAD+X8M5UzqyZ9k3FFZLBTtqo6JLPwV53cbRB/mJwBI0PxcIgqhBBHlEs8G45OTDTMq3gNcLq3A==}
+  zustand@5.0.7:
+    resolution: {integrity: sha512-Ot6uqHDW/O2VdYsKLLU8GQu8sCOM1LcoE8RwvLv9uuRT9s6SOHCKs0ZEOhxg+I1Ld+A1Q5lwx+UlKXXUoCZITg==}
     engines: {node: '>=12.20.0'}
     peerDependencies:
       '@types/react': '>=18.0.0'
@@ -5299,6 +5316,8 @@ snapshots:
 
   '@babel/runtime@7.27.6': {}
 
+  '@babel/runtime@7.28.2': {}
+
   '@babel/template@7.27.2':
     dependencies:
       '@babel/code-frame': 7.27.1
@@ -5322,9 +5341,14 @@ snapshots:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.27.1
 
-  '@cartridge/connector@0.9.1(@metamask/sdk@0.32.1(bufferutil@4.0.9)(encoding@0.1.13)(utf-8-validate@5.0.10))(@solana/web3.js@1.98.2(bufferutil@4.0.9)(encoding@0.1.13)(typescript@5.8.3)(utf-8-validate@5.0.10))(@starknet-react/core@4.0.1-beta.4(bufferutil@4.0.9)(get-starknet-core@4.0.0)(react@18.3.1)(starknet@7.6.4)(typescript@5.8.3)(utf-8-validate@5.0.10))(@types/react@18.3.23)(bufferutil@4.0.9)(encoding@0.1.13)(open@10.2.0)(react@18.3.1)(starknet@7.6.4)(starknetkit@2.12.1(7527e31a67a40c689e60e5c9888af2ed))(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.76)':
+  '@babel/types@7.28.2':
     dependencies:
-      '@cartridge/controller': 0.9.1(@metamask/sdk@0.32.1(bufferutil@4.0.9)(encoding@0.1.13)(utf-8-validate@5.0.10))(@solana/web3.js@1.98.2(bufferutil@4.0.9)(encoding@0.1.13)(typescript@5.8.3)(utf-8-validate@5.0.10))(@types/react@18.3.23)(bufferutil@4.0.9)(encoding@0.1.13)(open@10.2.0)(react@18.3.1)(starknet@7.6.4)(starknetkit@2.12.1(7527e31a67a40c689e60e5c9888af2ed))(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      '@babel/helper-string-parser': 7.27.1
+      '@babel/helper-validator-identifier': 7.27.1
+
+  '@cartridge/connector@0.9.2(@metamask/sdk@0.32.1(bufferutil@4.0.9)(encoding@0.1.13)(utf-8-validate@5.0.10))(@solana/web3.js@1.98.2(bufferutil@4.0.9)(encoding@0.1.13)(typescript@5.8.3)(utf-8-validate@5.0.10))(@starknet-react/core@4.0.1-beta.4(bufferutil@4.0.9)(get-starknet-core@4.0.0)(react@18.3.1)(starknet@7.6.4)(typescript@5.8.3)(utf-8-validate@5.0.10))(@types/react@18.3.23)(bufferutil@4.0.9)(encoding@0.1.13)(open@10.2.0)(react@18.3.1)(starknet@7.6.4)(starknetkit@2.12.1(7527e31a67a40c689e60e5c9888af2ed))(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.76)':
+    dependencies:
+      '@cartridge/controller': 0.9.2(@metamask/sdk@0.32.1(bufferutil@4.0.9)(encoding@0.1.13)(utf-8-validate@5.0.10))(@solana/web3.js@1.98.2(bufferutil@4.0.9)(encoding@0.1.13)(typescript@5.8.3)(utf-8-validate@5.0.10))(@types/react@18.3.23)(bufferutil@4.0.9)(encoding@0.1.13)(open@10.2.0)(react@18.3.1)(starknet@7.6.4)(starknetkit@2.12.1(7527e31a67a40c689e60e5c9888af2ed))(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.76)
       '@starknet-react/core': 4.0.1-beta.4(bufferutil@4.0.9)(get-starknet-core@4.0.0)(react@18.3.1)(starknet@7.6.4)(typescript@5.8.3)(utf-8-validate@5.0.10)
     transitivePeerDependencies:
       - '@azure/app-configuration'
@@ -5360,7 +5384,7 @@ snapshots:
 
   '@cartridge/controller-wasm@0.2.3': {}
 
-  '@cartridge/controller@0.9.1(@metamask/sdk@0.32.1(bufferutil@4.0.9)(encoding@0.1.13)(utf-8-validate@5.0.10))(@solana/web3.js@1.98.2(bufferutil@4.0.9)(encoding@0.1.13)(typescript@5.8.3)(utf-8-validate@5.0.10))(@types/react@18.3.23)(bufferutil@4.0.9)(encoding@0.1.13)(open@10.2.0)(react@18.3.1)(starknet@7.6.4)(starknetkit@2.12.1(7527e31a67a40c689e60e5c9888af2ed))(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.76)':
+  '@cartridge/controller@0.9.2(@metamask/sdk@0.32.1(bufferutil@4.0.9)(encoding@0.1.13)(utf-8-validate@5.0.10))(@solana/web3.js@1.98.2(bufferutil@4.0.9)(encoding@0.1.13)(typescript@5.8.3)(utf-8-validate@5.0.10))(@types/react@18.3.23)(bufferutil@4.0.9)(encoding@0.1.13)(open@10.2.0)(react@18.3.1)(starknet@7.6.4)(starknetkit@2.12.1(7527e31a67a40c689e60e5c9888af2ed))(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.76)':
     dependencies:
       '@cartridge/controller-wasm': 0.2.3
       '@cartridge/penpal': 6.2.4
@@ -5866,14 +5890,14 @@ snapshots:
     dependencies:
       '@jest/fake-timers': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 24.0.15
+      '@types/node': 24.2.0
       jest-mock: 29.7.0
 
   '@jest/fake-timers@29.7.0':
     dependencies:
       '@jest/types': 29.6.3
       '@sinonjs/fake-timers': 10.3.0
-      '@types/node': 24.0.15
+      '@types/node': 24.2.0
       jest-message-util: 29.7.0
       jest-mock: 29.7.0
       jest-util: 29.7.0
@@ -5907,7 +5931,7 @@ snapshots:
       '@jest/schemas': 29.6.3
       '@types/istanbul-lib-coverage': 2.0.6
       '@types/istanbul-reports': 3.0.4
-      '@types/node': 24.0.15
+      '@types/node': 24.2.0
       '@types/yargs': 17.0.33
       chalk: 4.1.2
 
@@ -6435,7 +6459,7 @@ snapshots:
 
   '@react-three/fiber@9.2.0(@types/react@18.3.23)(immer@10.1.1)(react-dom@18.3.1(react@18.3.1))(react-native@0.80.1(@babel/core@7.28.0)(@types/react@18.3.23)(bufferutil@4.0.9)(react@18.3.1)(utf-8-validate@5.0.10))(react@18.3.1)(three@0.178.0)':
     dependencies:
-      '@babel/runtime': 7.27.6
+      '@babel/runtime': 7.28.2
       '@types/react-reconciler': 0.28.9(@types/react@18.3.23)
       '@types/webxr': 0.5.22
       base64-js: 1.5.1
@@ -6448,7 +6472,7 @@ snapshots:
       suspend-react: 0.1.3(react@18.3.1)
       three: 0.178.0
       use-sync-external-store: 1.5.0(react@18.3.1)
-      zustand: 5.0.6(@types/react@18.3.23)(immer@10.1.1)(react@18.3.1)(use-sync-external-store@1.5.0(react@18.3.1))
+      zustand: 5.0.7(@types/react@18.3.23)(immer@10.1.1)(react@18.3.1)(use-sync-external-store@1.5.0(react@18.3.1))
     optionalDependencies:
       react-dom: 18.3.1(react@18.3.1)
       react-native: 0.80.1(@babel/core@7.28.0)(@types/react@18.3.23)(bufferutil@4.0.9)(react@18.3.1)(utf-8-validate@5.0.10)
@@ -7146,6 +7170,10 @@ snapshots:
     dependencies:
       '@babel/types': 7.28.1
 
+  '@types/babel__traverse@7.28.0':
+    dependencies:
+      '@babel/types': 7.28.2
+
   '@types/connect@3.4.38':
     dependencies:
       '@types/node': 24.0.15
@@ -7182,7 +7210,7 @@ snapshots:
 
   '@types/graceful-fs@4.1.9':
     dependencies:
-      '@types/node': 24.0.15
+      '@types/node': 24.2.0
 
   '@types/istanbul-lib-coverage@2.0.6': {}
 
@@ -7213,6 +7241,10 @@ snapshots:
   '@types/node@24.0.15':
     dependencies:
       undici-types: 7.8.0
+
+  '@types/node@24.2.0':
+    dependencies:
+      undici-types: 7.10.0
 
   '@types/parse-json@4.0.2': {}
 
@@ -7361,7 +7393,7 @@ snapshots:
       '@typescript-eslint/types': 8.37.0
       eslint-visitor-keys: 4.2.1
 
-  '@vitejs/plugin-react@4.7.0(vite@5.4.19(@types/node@24.0.15)(terser@5.43.1))':
+  '@vitejs/plugin-react@4.7.0(vite@5.4.19(@types/node@24.2.0)(terser@5.43.1))':
     dependencies:
       '@babel/core': 7.28.0
       '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.28.0)
@@ -7369,7 +7401,7 @@ snapshots:
       '@rolldown/pluginutils': 1.0.0-beta.27
       '@types/babel__core': 7.20.5
       react-refresh: 0.17.0
-      vite: 5.4.19(@types/node@24.0.15)(terser@5.43.1)
+      vite: 5.4.19(@types/node@24.2.0)(terser@5.43.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -8060,9 +8092,9 @@ snapshots:
   babel-plugin-jest-hoist@29.6.3:
     dependencies:
       '@babel/template': 7.27.2
-      '@babel/types': 7.28.1
+      '@babel/types': 7.28.2
       '@types/babel__core': 7.20.5
-      '@types/babel__traverse': 7.20.7
+      '@types/babel__traverse': 7.28.0
 
   babel-plugin-macros@3.1.0:
     dependencies:
@@ -8074,7 +8106,7 @@ snapshots:
     dependencies:
       hermes-parser: 0.28.1
 
-  babel-preset-current-node-syntax@1.1.0(@babel/core@7.28.0):
+  babel-preset-current-node-syntax@1.2.0(@babel/core@7.28.0):
     dependencies:
       '@babel/core': 7.28.0
       '@babel/plugin-syntax-async-generators': 7.8.4(@babel/core@7.28.0)
@@ -8097,7 +8129,7 @@ snapshots:
     dependencies:
       '@babel/core': 7.28.0
       babel-plugin-jest-hoist: 29.6.3
-      babel-preset-current-node-syntax: 1.1.0(@babel/core@7.28.0)
+      babel-preset-current-node-syntax: 1.2.0(@babel/core@7.28.0)
 
   balanced-match@1.0.2: {}
 
@@ -8258,7 +8290,7 @@ snapshots:
 
   chrome-launcher@0.15.2:
     dependencies:
-      '@types/node': 24.0.15
+      '@types/node': 24.2.0
       escape-string-regexp: 4.0.0
       is-wsl: 2.2.0
       lighthouse-logger: 1.4.2
@@ -8267,7 +8299,7 @@ snapshots:
 
   chromium-edge-launcher@0.2.0:
     dependencies:
-      '@types/node': 24.0.15
+      '@types/node': 24.2.0
       escape-string-regexp: 4.0.0
       is-wsl: 2.2.0
       lighthouse-logger: 1.4.2
@@ -9026,7 +9058,7 @@ snapshots:
 
   history@5.3.0:
     dependencies:
-      '@babel/runtime': 7.27.6
+      '@babel/runtime': 7.28.2
 
   hmac-drbg@1.0.1:
     dependencies:
@@ -9252,7 +9284,7 @@ snapshots:
       '@jest/environment': 29.7.0
       '@jest/fake-timers': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 24.0.15
+      '@types/node': 24.2.0
       jest-mock: 29.7.0
       jest-util: 29.7.0
 
@@ -9262,7 +9294,7 @@ snapshots:
     dependencies:
       '@jest/types': 29.6.3
       '@types/graceful-fs': 4.1.9
-      '@types/node': 24.0.15
+      '@types/node': 24.2.0
       anymatch: 3.1.3
       fb-watchman: 2.0.2
       graceful-fs: 4.2.11
@@ -9289,7 +9321,7 @@ snapshots:
   jest-mock@29.7.0:
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 24.0.15
+      '@types/node': 24.2.0
       jest-util: 29.7.0
 
   jest-regex-util@29.6.3: {}
@@ -9297,7 +9329,7 @@ snapshots:
   jest-util@29.7.0:
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 24.0.15
+      '@types/node': 24.2.0
       chalk: 4.1.2
       ci-info: 3.9.0
       graceful-fs: 4.2.11
@@ -9314,7 +9346,7 @@ snapshots:
 
   jest-worker@29.7.0:
     dependencies:
-      '@types/node': 24.0.15
+      '@types/node': 24.2.0
       jest-util: 29.7.0
       merge-stream: 2.0.0
       supports-color: 8.1.1
@@ -9544,14 +9576,14 @@ snapshots:
 
   metro-runtime@0.82.5:
     dependencies:
-      '@babel/runtime': 7.27.6
+      '@babel/runtime': 7.28.2
       flow-enums-runtime: 0.0.6
 
   metro-source-map@0.82.5:
     dependencies:
       '@babel/traverse': 7.28.0
       '@babel/traverse--for-generate-function-map': '@babel/traverse@7.28.0'
-      '@babel/types': 7.28.1
+      '@babel/types': 7.28.2
       flow-enums-runtime: 0.0.6
       invariant: 2.2.4
       metro-symbolicate: 0.82.5
@@ -9589,7 +9621,7 @@ snapshots:
       '@babel/core': 7.28.0
       '@babel/generator': 7.28.0
       '@babel/parser': 7.28.0
-      '@babel/types': 7.28.1
+      '@babel/types': 7.28.2
       flow-enums-runtime: 0.0.6
       metro: 0.82.5(bufferutil@4.0.9)(utf-8-validate@5.0.10)
       metro-babel-transformer: 0.82.5
@@ -9612,7 +9644,7 @@ snapshots:
       '@babel/parser': 7.28.0
       '@babel/template': 7.27.2
       '@babel/traverse': 7.28.0
-      '@babel/types': 7.28.1
+      '@babel/types': 7.28.2
       accepts: 1.3.8
       chalk: 4.1.2
       ci-info: 2.0.0
@@ -10018,7 +10050,7 @@ snapshots:
 
   react-clientside-effect@1.2.8(react@18.3.1):
     dependencies:
-      '@babel/runtime': 7.27.6
+      '@babel/runtime': 7.28.2
       react: 18.3.1
 
   react-copy-to-clipboard@5.1.0(react@18.3.1):
@@ -10051,7 +10083,7 @@ snapshots:
 
   react-focus-lock@2.13.6(@types/react@18.3.23)(react@18.3.1):
     dependencies:
-      '@babel/runtime': 7.27.6
+      '@babel/runtime': 7.28.2
       focus-lock: 1.3.6
       prop-types: 15.8.1
       react: 18.3.1
@@ -10838,6 +10870,8 @@ snapshots:
 
   undici-types@6.19.8: {}
 
+  undici-types@7.10.0: {}
+
   undici-types@7.8.0: {}
 
   universalify@2.0.1: {}
@@ -11036,37 +11070,37 @@ snapshots:
       - utf-8-validate
       - zod
 
-  vite-plugin-mkcert@1.17.8(vite@5.4.19(@types/node@24.0.15)(terser@5.43.1)):
+  vite-plugin-mkcert@1.17.8(vite@5.4.19(@types/node@24.2.0)(terser@5.43.1)):
     dependencies:
       axios: 1.10.0(debug@4.4.1)
       debug: 4.4.1
       picocolors: 1.1.1
-      vite: 5.4.19(@types/node@24.0.15)(terser@5.43.1)
+      vite: 5.4.19(@types/node@24.2.0)(terser@5.43.1)
     transitivePeerDependencies:
       - supports-color
 
-  vite-plugin-top-level-await@1.6.0(@swc/helpers@0.5.17)(rollup@4.45.1)(vite@5.4.19(@types/node@24.0.15)(terser@5.43.1)):
+  vite-plugin-top-level-await@1.6.0(@swc/helpers@0.5.17)(rollup@4.45.1)(vite@5.4.19(@types/node@24.2.0)(terser@5.43.1)):
     dependencies:
       '@rollup/plugin-virtual': 3.0.2(rollup@4.45.1)
       '@swc/core': 1.13.0(@swc/helpers@0.5.17)
       '@swc/wasm': 1.13.0
       uuid: 10.0.0
-      vite: 5.4.19(@types/node@24.0.15)(terser@5.43.1)
+      vite: 5.4.19(@types/node@24.2.0)(terser@5.43.1)
     transitivePeerDependencies:
       - '@swc/helpers'
       - rollup
 
-  vite-plugin-wasm@3.5.0(vite@5.4.19(@types/node@24.0.15)(terser@5.43.1)):
+  vite-plugin-wasm@3.5.0(vite@5.4.19(@types/node@24.2.0)(terser@5.43.1)):
     dependencies:
-      vite: 5.4.19(@types/node@24.0.15)(terser@5.43.1)
+      vite: 5.4.19(@types/node@24.2.0)(terser@5.43.1)
 
-  vite@5.4.19(@types/node@24.0.15)(terser@5.43.1):
+  vite@5.4.19(@types/node@24.2.0)(terser@5.43.1):
     dependencies:
       esbuild: 0.21.5
       postcss: 8.5.6
       rollup: 4.45.1
     optionalDependencies:
-      '@types/node': 24.0.15
+      '@types/node': 24.2.0
       fsevents: 2.3.3
       terser: 5.43.1
 
@@ -11230,7 +11264,7 @@ snapshots:
       immer: 10.1.1
       react: 18.3.1
 
-  zustand@5.0.6(@types/react@18.3.23)(immer@10.1.1)(react@18.3.1)(use-sync-external-store@1.5.0(react@18.3.1)):
+  zustand@5.0.7(@types/react@18.3.23)(immer@10.1.1)(react@18.3.1)(use-sync-external-store@1.5.0(react@18.3.1)):
     optionalDependencies:
       '@types/react': 18.3.23
       immer: 10.1.1

--- a/client/src/contexts/metagame.tsx
+++ b/client/src/contexts/metagame.tsx
@@ -1,9 +1,8 @@
-import { ReactNode, useState, useEffect } from "react";
-import { useNetwork } from "@starknet-react/core";
 import {
   initMetagame,
   MetagameProvider as MetagameSDKProvider,
 } from "metagame-sdk";
+import { ReactNode, useEffect, useState } from "react";
 // import { feltToString } from "@/lib/utils";
 // import { ChainId, CHAINS } from "@/dojo/setup/networks";
 // import { manifests } from "@/dojo/setup/config";
@@ -11,12 +10,10 @@ import { useDynamicConnector } from "@/contexts/starknet.tsx";
 
 export const MetagameProvider = ({ children }: { children: ReactNode }) => {
   const [metagameClient, setMetagameClient] = useState<any>(undefined);
-  const { chain } = useNetwork();
   const { dojoConfig } = useDynamicConnector();
 
   useEffect(() => {
     if (!dojoConfig) {
-      console.error(`No config found for chain ID: ${chain.id}`);
       setMetagameClient(undefined);
       return;
     }
@@ -29,12 +26,12 @@ export const MetagameProvider = ({ children }: { children: ReactNode }) => {
       .then(setMetagameClient)
       .catch((error) => {
         console.error(
-          `Failed to initialize Metagame SDK for chain ${chain.id}:`,
+          `Failed to initialize Metagame SDK for chain ${dojoConfig.chainId}:`,
           error
         );
         setMetagameClient(undefined);
       });
-  }, [chain]);
+  }, [dojoConfig]);
 
   if (!metagameClient) {
     return (

--- a/client/src/desktop/components/AdventurersList.tsx
+++ b/client/src/desktop/components/AdventurersList.tsx
@@ -1,20 +1,19 @@
+import { useController } from "@/contexts/controller";
+import { useDojoConfig } from "@/contexts/starknet";
+import { useGameTokens } from "@/dojo/useGameTokens";
+import { calculateLevel } from "@/utils/game";
+import { getContractByName } from "@dojoengine/core";
+import AccessTimeIcon from "@mui/icons-material/AccessTime";
+import ArrowBackIcon from "@mui/icons-material/ArrowBack";
+import ArrowForwardIcon from "@mui/icons-material/ArrowForward";
+import WatchIcon from "@mui/icons-material/Watch";
 import { Box, Button, Typography } from "@mui/material";
 import { motion } from "framer-motion";
-import { useEffect, useState, useMemo } from "react";
-import { useNavigate } from "react-router-dom";
-import { useController } from "@/contexts/controller";
-import { useGameTokens } from "@/dojo/useGameTokens";
 import {
-  useGameTokens as useMetagameTokens,
-  GameTokenData,
+  useGameTokens as useMetagameTokens
 } from "metagame-sdk";
-import ArrowForwardIcon from "@mui/icons-material/ArrowForward";
-import AccessTimeIcon from "@mui/icons-material/AccessTime";
-import WatchIcon from "@mui/icons-material/Watch";
-import { calculateLevel } from "@/utils/game";
-import ArrowBackIcon from "@mui/icons-material/ArrowBack";
-import { getContractByName } from "@dojoengine/core";
-import { useDojoConfig } from "@/contexts/starknet";
+import { useEffect, useState } from "react";
+import { useNavigate } from "react-router-dom";
 
 interface AdventurersListProps {
   onBack: () => void;

--- a/client/src/desktop/components/Network.tsx
+++ b/client/src/desktop/components/Network.tsx
@@ -1,0 +1,103 @@
+import { useDynamicConnector } from '@/contexts/starknet';
+import { ChainId, getNetworkConfig, NetworkConfig, NETWORKS } from '@/utils/networkConfig';
+import FiberManualRecordIcon from '@mui/icons-material/FiberManualRecord';
+import { Box, Button, Menu, MenuItem } from '@mui/material';
+import { useState } from 'react';
+
+function Network() {
+  const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
+  const { setCurrentNetworkConfig, currentNetworkConfig } = useDynamicConnector();
+
+  const handleClick = (event: React.MouseEvent<HTMLElement>) => {
+    setAnchorEl(event.currentTarget);
+  };
+
+  const handleClose = () => {
+    setAnchorEl(null);
+  };
+
+  const handleNetworkSwitch = async (networkKey: ChainId) => {
+    setCurrentNetworkConfig(getNetworkConfig(networkKey) as NetworkConfig);
+
+    handleClose();
+  };
+
+  const getStatusColor = (status: string) => {
+    return status === 'online' ? '#4CAF50' : '#F44336';
+  };
+
+  return (
+    <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, width: '100%' }}>
+      <Button
+        variant="outlined"
+        onClick={handleClick}
+        fullWidth
+        sx={{
+          borderColor: '#d7c529',
+          color: '#d7c529',
+          '&:hover': {
+            borderColor: '#b59f3b',
+            backgroundColor: 'rgba(183, 159, 59, 0.1)'
+          },
+          height: '36px',
+          textTransform: 'none',
+          fontWeight: 500,
+          display: 'flex',
+          justifyContent: 'space-between',
+          alignItems: 'center',
+          padding: '8px 12px'
+        }}
+      >
+        {currentNetworkConfig.name}
+        <FiberManualRecordIcon
+          sx={{
+            color: getStatusColor(currentNetworkConfig.status),
+            fontSize: 12
+          }}
+        />
+      </Button>
+
+      <Menu
+        anchorEl={anchorEl}
+        open={Boolean(anchorEl)}
+        onClose={handleClose}
+        slotProps={{
+          paper: {
+            sx: {
+              mt: 0.5,
+              minWidth: 310,
+              boxShadow: '0 4px 20px rgba(0,0,0,0.1)',
+            }
+          }
+        }}
+      >
+        {Object.entries(NETWORKS).map(([key, network]) => (
+          <MenuItem
+            key={network.name}
+            onClick={() => handleNetworkSwitch(key as ChainId)}
+            sx={{
+              display: 'flex',
+              justifyContent: 'space-between',
+              alignItems: 'center',
+              gap: 1,
+              backgroundColor: key === currentNetworkConfig.chainId ? 'rgba(215, 197, 41, 0.1)' : 'transparent',
+              '&:hover': {
+                backgroundColor: key === currentNetworkConfig.chainId ? 'rgba(215, 197, 41, 0.2)' : 'rgba(215, 197, 41, 0.05)',
+              }
+            }}
+          >
+            {network.name}
+            <FiberManualRecordIcon
+              sx={{
+                color: getStatusColor(network.status || 'offline'),
+                fontSize: 10
+              }}
+            />
+          </MenuItem>
+        ))}
+      </Menu>
+    </Box>
+  );
+}
+
+export default Network;

--- a/client/src/desktop/components/WalletConnect.tsx
+++ b/client/src/desktop/components/WalletConnect.tsx
@@ -2,9 +2,11 @@ import { useController } from '@/contexts/controller';
 import { ellipseAddress } from '@/utils/utils';
 import SportsEsportsOutlinedIcon from '@mui/icons-material/SportsEsportsOutlined';
 import { Button } from '@mui/material';
+import { useAccount } from '@starknet-react/core';
 
 function WalletConnect() {
-  const { account, address, isPending, playerName, login, openProfile } = useController()
+  const { isPending, playerName, login, openProfile } = useController()
+  const { account, address } = useAccount();
 
   return (
     <>
@@ -17,7 +19,7 @@ function WalletConnect() {
           size='small'
           fullWidth
           startIcon={<SportsEsportsOutlinedIcon htmlColor='secondary.contrastText' />}
-          sx={{ justifyContent: 'center', color: 'secondary.contrastText', opacity: 1 }}
+          sx={{ justifyContent: 'center', color: 'secondary.contrastText', opacity: 1, height: '40px' }}
         >
           {playerName ? playerName : ellipseAddress(address, 4, 4)}
         </Button>
@@ -30,7 +32,7 @@ function WalletConnect() {
           size='small'
           fullWidth
           startIcon={<SportsEsportsOutlinedIcon htmlColor='secondary.contrastText' />}
-          sx={{ justifyContent: 'center', color: 'secondary.contrastText' }}
+          sx={{ justifyContent: 'center', color: 'secondary.contrastText', height: '40px' }}
         >
           Log In
         </Button>

--- a/client/src/desktop/overlays/MainMenu.tsx
+++ b/client/src/desktop/overlays/MainMenu.tsx
@@ -1,9 +1,9 @@
 import { useController } from '@/contexts/controller';
+import { useDynamicConnector } from '@/contexts/starknet';
 import discordIcon from '@/desktop/assets/images/discord.png';
 import AdventurersList from '@/desktop/components/AdventurersList';
 import Settings from '@/desktop/components/Settings';
 import { getMenuLeftOffset } from '@/utils/utils';
-import BarChartIcon from '@mui/icons-material/BarChart';
 import GitHubIcon from '@mui/icons-material/GitHub';
 import SettingsOutlinedIcon from '@mui/icons-material/SettingsOutlined';
 import ShieldOutlinedIcon from '@mui/icons-material/ShieldOutlined';
@@ -13,17 +13,21 @@ import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
 import Divider from '@mui/material/Divider';
 import IconButton from '@mui/material/IconButton';
-import LinearProgress from '@mui/material/LinearProgress';
-import Stack from '@mui/material/Stack';
 import Typography from '@mui/material/Typography';
 import { AnimatePresence } from 'framer-motion';
 import { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
+import Network from '../components/Network';
+import WalletConnect from '../components/WalletConnect';
 import StatisticsModal from './StatisticsModal';
+import { useAccount } from '@starknet-react/core';
+import { ChainId } from '@/utils/networkConfig';
 
 export default function MainMenu() {
   const navigate = useNavigate();
-  const { address } = useController();
+  const { account } = useAccount();
+  const { login } = useController();
+  const { currentNetworkConfig } = useDynamicConnector();
   const [showAdventurers, setShowAdventurers] = useState(false);
   const [showSettings, setShowSettings] = useState(false);
   const [showStats, setShowStats] = useState(false);
@@ -38,7 +42,21 @@ export default function MainMenu() {
   }, []);
 
   const handleStartGame = () => {
+    if (currentNetworkConfig.chainId === ChainId.SN_SEPOLIA && !account) {
+      login();
+      return;
+    }
+
     navigate(`/survivor/play`);
+  };
+
+  const handleShowAdventurers = () => {
+    if (currentNetworkConfig.chainId === ChainId.SN_SEPOLIA && !account) {
+      login();
+      return;
+    }
+
+    setShowAdventurers(true);
   };
 
   return (
@@ -54,15 +72,13 @@ export default function MainMenu() {
                 LOOT SURVIVOR 2
               </Typography>
               <Typography color="secondary" sx={styles.modeTitle}>
-                Beast Mode
+                {currentNetworkConfig.name}
               </Typography>
             </Box>
 
             {/* <PriceIndicator /> */}
 
-
             <Button
-              disabled={!address}
               variant="outlined"
               fullWidth
               size="large"
@@ -71,40 +87,24 @@ export default function MainMenu() {
             >
               <Box sx={{ display: 'flex', alignItems: 'center' }}>
                 <TokenIcon sx={{ fontSize: 20, mr: 1 }} />
-                <Typography sx={{ fontSize: '0.85rem', fontWeight: 500, letterSpacing: 0.5, color: !address ? 'rgba(255, 255, 255, 0.3)' : '#d0c98d' }}>
+                <Typography sx={{ fontSize: '0.85rem', fontWeight: 500, letterSpacing: 0.5, color: '#d0c98d' }}>
                   New Game
                 </Typography>
               </Box>
             </Button>
 
             <Button
-              disabled={!address}
               variant="outlined"
               fullWidth
               size="large"
-              onClick={() => setShowAdventurers(true)}
+              onClick={handleShowAdventurers}
               sx={{ pl: 1, height: '36px' }}
             >
               <ShieldOutlinedIcon sx={{ fontSize: 20, mr: 1 }} />
-              <Typography sx={{ fontSize: '0.85rem', fontWeight: 500, letterSpacing: 0.5, color: !address ? 'rgba(255, 255, 255, 0.3)' : '#d0c98d' }}>
+              <Typography sx={{ fontSize: '0.85rem', fontWeight: 500, letterSpacing: 0.5, color: '#d0c98d' }}>
                 My Adventurers
               </Typography>
             </Button>
-
-            {/* <Button
-              variant="outlined"
-              fullWidth
-              size="large"
-              onClick={() => navigate('/survivor/play?mode=practice')}
-              sx={{ px: 1, display: 'flex', alignItems: 'center', justifyContent: 'space-between', height: '36px' }}
-            >
-              <Box sx={{ display: 'flex', alignItems: 'center' }}>
-                <img src={practiceIcon} alt="Practice" style={{ width: 20, height: 20, marginRight: '8px' }} />
-                <Typography sx={{ fontSize: '0.85rem', color: '#d0c98d', fontWeight: 500, letterSpacing: 0.5 }}>
-                  Practice
-                </Typography>
-              </Box>
-            </Button> */}
 
             <Divider sx={{ width: '100%', my: 0.5 }} />
 
@@ -121,7 +121,7 @@ export default function MainMenu() {
               </Typography>
             </Button>
 
-            <Button
+            {/* <Button
               variant="outlined"
               fullWidth
               size="large"
@@ -133,11 +133,13 @@ export default function MainMenu() {
               <Typography sx={{ fontSize: '0.85rem', color: 'rgba(255, 255, 255, 0.3)', fontWeight: 500, letterSpacing: 0.5 }}>
                 Statistics
               </Typography>
-            </Button>
+            </Button> */}
 
             <Box sx={styles.bottom}>
+              <Network />
+              <WalletConnect />
 
-              <Stack spacing={0.5} sx={{ width: '100%', mb: 1 }}>
+              {/* {currentNetworkConfig.name === "Beast Mode" && <Stack spacing={0.5} sx={{ width: '100%' }}>
                 <Box sx={{ display: 'flex', alignItems: 'center', width: '100%', justifyContent: 'space-between' }}>
                   <Typography sx={{ fontSize: '0.85rem', color: '#d0c98d', fontWeight: 500, letterSpacing: 0.5 }}>
                     Beasts Collected
@@ -170,12 +172,11 @@ export default function MainMenu() {
                     }}
                   />
                 </Box>
-              </Stack>
-              {/* <WalletConnect /> */}
+              </Stack>} */}
 
               <Box sx={styles.bottomRow}>
                 <Typography sx={styles.alphaVersion}>
-                  TEST VERSION 0.0.1
+                  Provable Games
                 </Typography>
                 <Box sx={styles.socialButtons}>
                   <IconButton size="small" sx={styles.socialButton} onClick={() => window.open('https://x.com/lootsurvivor', '_blank')}>
@@ -261,10 +262,12 @@ const styles = {
     width: '100%',
   },
   bottomRow: {
+    mt: 0.5,
     display: 'flex',
     alignItems: 'center',
     justifyContent: 'space-between',
-    width: '100%',
+    width: '99%',
+    mr: -1
   },
   socialButtons: {
     display: 'flex',

--- a/client/src/dojo/useGameTokens.ts
+++ b/client/src/dojo/useGameTokens.ts
@@ -1,52 +1,21 @@
-import { ClauseBuilder, ToriiQueryBuilder } from "@dojoengine/sdk";
-import { hexToAscii } from "@dojoengine/utils";
-import { addAddressPadding } from "starknet";
 import { useDojoConfig } from "@/contexts/starknet";
+import { addAddressPadding } from "starknet";
 
 import { useGameStore } from "@/stores/gameStore";
-import { useEntityModel } from "@/types/game";
 import { getShortNamespace } from "@/utils/utils";
-import { getContractByName } from "@dojoengine/core";
 import { gql, request } from "graphql-request";
 import { GameTokenData } from "metagame-sdk";
 
 export const useGameTokens = () => {
   const dojoConfig = useDojoConfig();
-  const { getEntityModel } = useEntityModel();
 
   const namespace = dojoConfig.namespace;
-  const GAME_TOKEN_ADDRESS = getContractByName(
-    dojoConfig.manifest,
-    namespace,
-    "game_token_systems"
-  )?.address;
   const NS_SHORT = getShortNamespace(namespace);
-
-  const fetchGameTokenIds = async (address: string) => {
-    let url = `${dojoConfig.toriiUrl}/sql?query=
-      SELECT token_id FROM token_balances
-      WHERE account_address = "${address.replace(
-        /^0x0+/,
-        "0x"
-      )}" AND contract_address = "${GAME_TOKEN_ADDRESS}"
-      LIMIT 10000`;
-
-    const sql = await fetch(url, {
-      method: "GET",
-      headers: {
-        "Content-Type": "application/json",
-      },
-    });
-
-    let data = await sql.json();
-    return data.map((token: any) => parseInt(token.token_id.split(":")[1], 16));
-  };
 
   const fetchMetadata = async (gameTokens: any, tokenId: number) => {
     const gameToken = gameTokens?.find(
       (token: any) => token.token_id === tokenId
     );
-    // console.log(gameToken, gameTokens, tokenId);
 
     if (gameToken) {
       useGameStore.getState().setMetadata({
@@ -57,115 +26,6 @@ export const useGameTokens = () => {
         available_at: parseInt(gameToken.lifecycle.start || 0, 16) * 1000,
       });
       return;
-    }
-  };
-
-  const fetchGameTokensData = async (tokenIds: string[]) => {
-    tokenIds = tokenIds.map((tokenId) => `"${tokenId.toString()}"`);
-
-    const document = gql`
-    {
-      ${NS_SHORT}TokenMetadataModels (limit:10000, where:{
-        token_idIN:[${tokenIds}]}
-      ){
-        edges {
-          node {
-            token_id
-            player_name
-            settings_id
-            minted_by
-            lifecycle {
-              start {
-                Some
-              }
-              end {
-                Some
-              }
-            }
-          }
-        }
-      }
-
-      ${NS_SHORT}GameEventModels (limit:10000, where:{
-        adventurer_idIN:[${tokenIds}]}
-      ){
-        edges {
-          node {
-            adventurer_id
-            details {
-              option
-              adventurer {
-                health
-                xp
-                gold
-                equipment {
-                  weapon {
-                    id
-                  }
-                  chest {
-                    id
-                  }
-                  head {
-                    id
-                  }
-                  waist {
-                    id
-                  }
-                  foot {
-                    id
-                  }
-                  hand {
-                    id
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-    }`;
-
-    try {
-      const res: any = await request(
-        dojoConfig.toriiUrl + "/graphql",
-        document
-      );
-      let tokenMetadata =
-        res?.[`${NS_SHORT}TokenMetadataModels`]?.edges.map(
-          (edge: any) => edge.node
-        ) ?? [];
-      let gameEvents =
-        res?.[`${NS_SHORT}GameEventModels`]?.edges.map(
-          (edge: any) => edge.node
-        ) ?? [];
-
-      let games = tokenMetadata.map((metaData: any) => {
-        let adventurerData = gameEvents.find(
-          (event: any) => event.adventurer_id === metaData.token_id
-        );
-        let adventurer = adventurerData?.details?.adventurer || {};
-
-        let tokenId = parseInt(metaData.token_id, 16);
-        let expires_at = parseInt(metaData.lifecycle.end.Some || 0, 16) * 1000;
-        let available_at =
-          parseInt(metaData.lifecycle.start.Some || 0, 16) * 1000;
-
-        return {
-          ...adventurer,
-          adventurer_id: tokenId,
-          player_name: hexToAscii(metaData.player_name),
-          settings_id: metaData.settings_id,
-          minted_by: metaData.minted_by,
-          expires_at,
-          available_at,
-          expired: expires_at !== 0 && expires_at < Date.now(),
-          dead: adventurer.xp !== 0 && adventurer.health === 0,
-        };
-      });
-
-      return games;
-    } catch (ex) {
-      return [];
     }
   };
 
@@ -255,9 +115,7 @@ export const useGameTokens = () => {
   };
 
   return {
-    fetchGameTokenIds,
     fetchMetadata,
-    fetchGameTokensData,
     fetchAdventurerData,
   };
 };

--- a/client/src/dojo/useSystemCalls.ts
+++ b/client/src/dojo/useSystemCalls.ts
@@ -2,8 +2,7 @@ import { useController } from "@/contexts/controller";
 import { useDojoConfig } from "@/contexts/starknet";
 import { GameSettingsData, ItemPurchase, Stats } from "@/types/game";
 import { getContractByName } from "@dojoengine/core";
-import { Call } from "@mui/icons-material";
-import { CallData, CairoOption, CairoOptionVariant, byteArray } from "starknet";
+import { CairoOption, CairoOptionVariant, CallData, byteArray } from "starknet";
 
 export const useSystemCalls = () => {
   const { account } = useController();
@@ -67,7 +66,7 @@ export const useSystemCalls = () => {
    * @param name The name of the game
    * @param settingsId The settings ID for the game
    */
-  const mintGame = async (account: any, name: string, settingsId = 0) => {
+  const mintGame = async (name: string, settingsId = 0) => {
     try {
       let tx = await account!.execute([
         {
@@ -121,7 +120,7 @@ export const useSystemCalls = () => {
 
     let calls: any[] = [
       {
-        contractAddress: GAME_TOKEN_ADDRESS,
+        contractAddress: GAME_ADDRESS,
         entrypoint: "start_game",
         calldata: [gameId, weapon],
       },
@@ -155,7 +154,7 @@ export const useSystemCalls = () => {
    */
   const explore = (gameId: number, tillBeast: boolean) => {
     return {
-      contractAddress: GAME_TOKEN_ADDRESS,
+      contractAddress: GAME_ADDRESS,
       entrypoint: "explore",
       calldata: [gameId, tillBeast],
     };
@@ -168,7 +167,7 @@ export const useSystemCalls = () => {
    */
   const attack = (gameId: number, toTheDeath: boolean) => {
     return {
-      contractAddress: GAME_TOKEN_ADDRESS,
+      contractAddress: GAME_ADDRESS,
       entrypoint: "attack",
       calldata: [gameId, toTheDeath],
     };
@@ -181,7 +180,7 @@ export const useSystemCalls = () => {
    */
   const flee = (gameId: number, toTheDeath: boolean) => {
     return {
-      contractAddress: GAME_TOKEN_ADDRESS,
+      contractAddress: GAME_ADDRESS,
       entrypoint: "flee",
       calldata: [gameId, toTheDeath],
     };
@@ -194,7 +193,7 @@ export const useSystemCalls = () => {
    */
   const equip = (gameId: number, items: number[]) => {
     return {
-      contractAddress: GAME_TOKEN_ADDRESS,
+      contractAddress: GAME_ADDRESS,
       entrypoint: "equip",
       calldata: [gameId, items],
     };
@@ -207,7 +206,7 @@ export const useSystemCalls = () => {
    */
   const drop = (gameId: number, items: number[]) => {
     return {
-      contractAddress: GAME_TOKEN_ADDRESS,
+      contractAddress: GAME_ADDRESS,
       entrypoint: "drop",
       calldata: [gameId, items],
     };
@@ -222,7 +221,7 @@ export const useSystemCalls = () => {
    */
   const buyItems = (gameId: number, potions: number, items: ItemPurchase[]) => {
     return {
-      contractAddress: GAME_TOKEN_ADDRESS,
+      contractAddress: GAME_ADDRESS,
       entrypoint: "buy_items",
       calldata: [gameId, potions, items],
     };
@@ -230,7 +229,7 @@ export const useSystemCalls = () => {
 
   const selectStatUpgrades = (gameId: number, statUpgrades: Stats) => {
     return {
-      contractAddress: GAME_TOKEN_ADDRESS,
+      contractAddress: GAME_ADDRESS,
       entrypoint: "select_stat_upgrades",
       calldata: [gameId, statUpgrades],
     };

--- a/client/src/mobile/components/Header.tsx
+++ b/client/src/mobile/components/Header.tsx
@@ -5,6 +5,7 @@ import { Box, IconButton } from '@mui/material';
 import { useState } from 'react';
 import { isMobile } from 'react-device-detect';
 import SettingsMenu from './HeaderMenu';
+import Network from './Network';
 import WalletConnect from './WalletConnect';
 
 function Header() {
@@ -29,6 +30,10 @@ function Header() {
 
 
       <Box sx={styles.headerButtons}>
+        <Box sx={styles.networkContainer}>
+          <Network />
+        </Box>
+
         {address && <WalletConnect />}
 
         <IconButton
@@ -65,7 +70,7 @@ const styles = {
   networkContainer: {
     display: 'flex',
     alignItems: 'center',
-    width: '100px'
+    width: '140px'
   },
   headerButtons: {
     display: 'flex',

--- a/client/src/mobile/components/Header.tsx
+++ b/client/src/mobile/components/Header.tsx
@@ -1,4 +1,3 @@
-import { useController } from '@/contexts/controller';
 import { useGameStore } from '@/stores/gameStore';
 import SettingsIcon from '@mui/icons-material/Settings';
 import { Box, IconButton } from '@mui/material';
@@ -10,7 +9,6 @@ import WalletConnect from './WalletConnect';
 
 function Header() {
   const { gameId, adventurer } = useGameStore();
-  const { address } = useController();
   const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
 
   const handleSettingsClick = (event: React.MouseEvent<HTMLElement>) => {
@@ -34,7 +32,7 @@ function Header() {
           <Network />
         </Box>
 
-        {address && <WalletConnect />}
+        <WalletConnect />
 
         <IconButton
           onClick={handleSettingsClick}

--- a/client/src/mobile/components/Network.tsx
+++ b/client/src/mobile/components/Network.tsx
@@ -1,0 +1,97 @@
+import { useDynamicConnector } from '@/contexts/starknet';
+import { ChainId, getNetworkConfig, NetworkConfig, NETWORKS } from '@/utils/networkConfig';
+import FiberManualRecordIcon from '@mui/icons-material/FiberManualRecord';
+import { Box, Button, Menu, MenuItem } from '@mui/material';
+import { useState } from 'react';
+
+function Network() {
+  const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
+  const { setCurrentNetworkConfig, currentNetworkConfig } = useDynamicConnector();
+
+  const handleClick = (event: React.MouseEvent<HTMLElement>) => {
+    setAnchorEl(event.currentTarget);
+  };
+
+  const handleClose = () => {
+    setAnchorEl(null);
+  };
+
+  const handleNetworkSwitch = async (networkKey: ChainId) => {
+    setCurrentNetworkConfig(getNetworkConfig(networkKey) as NetworkConfig);
+
+    handleClose();
+  };
+
+  const getStatusColor = (status: string) => {
+    return status === 'online' ? '#4CAF50' : '#F44336';
+  };
+
+  return (
+    <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, width: '100%' }}>
+      <Button
+        variant="outlined"
+        onClick={handleClick}
+        fullWidth
+        sx={{
+          height: '34px',
+          textTransform: 'none',
+          fontWeight: 500,
+          display: 'flex',
+          justifyContent: 'space-between',
+          alignItems: 'center',
+          padding: '8px 16px'
+        }}
+      >
+        {currentNetworkConfig.name}
+        <FiberManualRecordIcon
+          sx={{
+            color: getStatusColor(currentNetworkConfig.status),
+            fontSize: 12
+          }}
+        />
+      </Button>
+
+      <Menu
+        anchorEl={anchorEl}
+        open={Boolean(anchorEl)}
+        onClose={handleClose}
+        slotProps={{
+          paper: {
+            sx: {
+              mt: 0.5,
+              minWidth: 142,
+              boxShadow: '0 4px 20px rgba(0,0,0,0.1)',
+            }
+          }
+        }}
+      >
+        {Object.entries(NETWORKS).map(([key, network]) => (
+          <MenuItem
+            key={network.name}
+            onClick={() => handleNetworkSwitch(key as ChainId)}
+            sx={{
+              display: 'flex',
+              justifyContent: 'space-between',
+              alignItems: 'center',
+              gap: 1,
+              backgroundColor: key === currentNetworkConfig.chainId ? 'rgba(215, 197, 41, 0.1)' : 'transparent',
+              '&:hover': {
+                backgroundColor: key === currentNetworkConfig.chainId ? 'rgba(215, 197, 41, 0.2)' : 'rgba(215, 197, 41, 0.05)',
+              }
+            }}
+          >
+            {network.name}
+            <FiberManualRecordIcon
+              sx={{
+                color: getStatusColor(network.status || 'offline'),
+                fontSize: 10
+              }}
+            />
+          </MenuItem>
+        ))}
+      </Menu>
+    </Box>
+  );
+}
+
+export default Network; 

--- a/client/src/mobile/components/WalletConnect.tsx
+++ b/client/src/mobile/components/WalletConnect.tsx
@@ -2,9 +2,11 @@ import { useController } from '@/contexts/controller';
 import { ellipseAddress } from '@/utils/utils';
 import SportsEsportsIcon from '@mui/icons-material/SportsEsports';
 import { Button } from '@mui/material';
+import { useAccount } from '@starknet-react/core';
 
 function WalletConnect() {
-  const { account, address, isPending, playerName, login, openProfile } = useController()
+  const { isPending, playerName, login, openProfile } = useController()
+  const { account, address } = useAccount();
 
   return (
     <>

--- a/client/src/mobile/pages/StartPage.tsx
+++ b/client/src/mobile/pages/StartPage.tsx
@@ -36,25 +36,6 @@ export default function LandingPage() {
             </Typography>
           </Button>
 
-          {!address && (
-            <>
-              <Box sx={styles.orDivider}>
-                <Box sx={{ flex: 1, height: '1px', bgcolor: 'rgba(255,255,255,0.3)' }} />
-                <Typography sx={styles.orText}>or</Typography>
-                <Box sx={{ flex: 1, height: '1px', bgcolor: 'rgba(255,255,255,0.3)' }} />
-              </Box>
-              <Button
-                fullWidth
-                variant="outlined"
-                size="small"
-                sx={{ textAlign: 'center', justifyContent: 'center', height: '36px' }}
-                onClick={() => navigate('/survivor/play?mode=practice')}
-              >
-                <Typography sx={{ fontSize: '0.8rem' }}>Play Practice</Typography>
-              </Button>
-            </>
-          )}
-
           {address && <>
             <Box sx={{ mt: 1.5, display: 'flex', alignItems: 'center', gap: 1, justifyContent: 'center' }}>
               <ArrowDropDownIcon color='primary' />

--- a/client/src/utils/networkConfig.ts
+++ b/client/src/utils/networkConfig.ts
@@ -28,28 +28,28 @@ export enum ChainId {
 }
 
 export const NETWORKS = {
-  SN_MAIN: {
-    chainId: ChainId.SN_MAIN,
-    name: "Mainnet",
-    status: "offline",
-    namespace: "ls_0_0_1",
-    slot: "pg-mainnet",
-    rpcUrl: "https://api.cartridge.gg/x/starknet/mainnet",
-    torii: "https://api.cartridge.gg/x/pg-mainnet/torii",
-    tokens: {
-      erc20: [],
-    },
-    manifest: manifest_sepolia,
-    vrf: true,
-  },
+  // SN_MAIN: {
+  //   chainId: ChainId.SN_MAIN,
+  //   name: "Beast Mode",
+  //   status: "offline",
+  //   namespace: "ls_0_0_1",
+  //   slot: "pg-mainnet",
+  //   rpcUrl: "https://api.cartridge.gg/x/starknet/mainnet",
+  //   torii: "https://api.cartridge.gg/x/pg-mainnet/torii",
+  //   tokens: {
+  //     erc20: [],
+  //   },
+  //   manifest: manifest_sepolia,
+  //   vrf: true,
+  // },
   SN_SEPOLIA: {
     chainId: ChainId.SN_SEPOLIA,
-    name: "Sepolia",
-    status: "offline",
-    namespace: "ls_0_0_1",
-    slot: "pg-sepolia",
+    name: "Beast Mode",
+    status: "online",
+    namespace: "ls_0_0_5",
+    slot: "pg-sepolia-2",
     rpcUrl: "https://api.cartridge.gg/x/starknet/sepolia",
-    torii: "https://api.cartridge.gg/x/pg-sepolia/torii",
+    torii: "https://api.cartridge.gg/x/pg-sepolia-2/torii",
     tokens: {
       erc20: [],
     },
@@ -58,7 +58,7 @@ export const NETWORKS = {
   },
   WP_PG_SLOT: {
     chainId: ChainId.WP_PG_SLOT,
-    name: "Katana",
+    name: "Practice Mode",
     status: "online",
     namespace: "ls_0_0_4",
     slot: "pg-slot",
@@ -96,7 +96,7 @@ export function getNetworkConfig(networkKey: ChainId): NetworkConfig {
   const policies = [
     {
       target: game_token_systems,
-      method: "mint",
+      method: "mint_game",
     },
     {
       target: game_systems,

--- a/contracts/.tool-versions
+++ b/contracts/.tool-versions
@@ -1,1 +1,1 @@
-dojo 1.6.0-alpha.2
+dojo 1.6.0

--- a/contracts/Scarb.lock
+++ b/contracts/Scarb.lock
@@ -66,16 +66,16 @@ dependencies = [
 
 [[package]]
 name = "dojo"
-version = "1.6.0-alpha.0"
-source = "git+https://github.com/dojoengine/dojo?tag=v1.6.0-alpha.2#184a4e8368269815823004d61e71f0699059ad77"
+version = "1.6.0"
+source = "git+https://github.com/dojoengine/dojo?tag=v1.6.0#c7d8b321abc711c14bddcf76f41587f6ef21c356"
 dependencies = [
  "dojo_plugin",
 ]
 
 [[package]]
 name = "dojo_cairo_test"
-version = "1.6.0-alpha.0"
-source = "git+https://github.com/dojoengine/dojo?tag=v1.6.0-alpha.2#184a4e8368269815823004d61e71f0699059ad77"
+version = "1.6.0"
+source = "git+https://github.com/dojoengine/dojo?tag=v1.6.0#c7d8b321abc711c14bddcf76f41587f6ef21c356"
 dependencies = [
  "dojo",
 ]
@@ -83,7 +83,7 @@ dependencies = [
 [[package]]
 name = "dojo_plugin"
 version = "2.10.1"
-source = "git+https://github.com/dojoengine/dojo?tag=v1.6.0-alpha.2#184a4e8368269815823004d61e71f0699059ad77"
+source = "git+https://github.com/dojoengine/dojo?tag=v1.6.0#c7d8b321abc711c14bddcf76f41587f6ef21c356"
 
 [[package]]
 name = "game_components_metagame"

--- a/contracts/Scarb.toml
+++ b/contracts/Scarb.toml
@@ -10,7 +10,7 @@ edition = "2024_07"
 sierra-replace-ids = true
 
 [dependencies]
-dojo = { git = "https://github.com/dojoengine/dojo", tag = "v1.6.0-alpha.2" }
+dojo = { git = "https://github.com/dojoengine/dojo", tag = "v1.6.0" }
 openzeppelin_token = "1.0.0"
 openzeppelin_introspection = "1.0.0"
 game_components_minigame = { git = "https://github.com/Provable-Games/game-components", tag = "0.0.7" }
@@ -23,7 +23,7 @@ graffiti = { git = "https://github.com/ponderingdemocritus/graffiti", rev = "bc5
 
 [dev-dependencies]
 cairo_test = "=2.10.1"
-dojo_cairo_test = { git = "https://github.com/dojoengine/dojo", tag = "v1.6.0-alpha.2" }
+dojo_cairo_test = { git = "https://github.com/dojoengine/dojo", tag = "v1.6.0" }
 
 [[target.starknet-contract]]
 sierra = true

--- a/contracts/dojo_sepolia.toml
+++ b/contracts/dojo_sepolia.toml
@@ -6,21 +6,23 @@ seed = "test_ls_0_6"
 [env]
 rpc_url = "https://api.cartridge.gg/x/starknet/sepolia"
 world_address = "0x38f6eb0186dfd1e072fa3b289b88e1c67b0baf1bd76cc6987f4a93258c69c4d"
+account_address = "0x065d2AB17338b5AffdEbAF95E2D79834B5f30Bac596fF55563c62C3c98700150"
+private_key = "0x0625adf89082edbffac775d64e9a5bba11483f6ef97c0925fb0433cb79d88581"
 
 [namespace]
-default = "ls_0_0_3"
+default = "ls_0_0_5"
 
 [writers]
-"ls_0_0_3" = [
-    "ls_0_0_3-game_systems", 
-    "ls_0_0_3-game_token_systems", 
-    "ls_0_0_3-settings_systems",
-    "ls_0_0_3-beast_systems",
-    "ls_0_0_3-adventurer_systems"
+"ls_0_0_5" = [
+    "ls_0_0_5-game_systems", 
+    "ls_0_0_5-game_token_systems", 
+    "ls_0_0_5-settings_systems",
+    "ls_0_0_5-beast_systems",
+    "ls_0_0_5-adventurer_systems"
 ]
 
 [init_call_args]
-"ls_0_0_3-game_token_systems" = [
+"ls_0_0_5-game_token_systems" = [
     "0x065d2AB17338b5AffdEbAF95E2D79834B5f30Bac596fF55563c62C3c98700150",
     "0x01fd7f186c0bb99f8d128f1eb40dbe3c7657df381957417f8c9a40804c005545" # denshokan_address
 ]

--- a/contracts/dojo_sepolia.toml
+++ b/contracts/dojo_sepolia.toml
@@ -1,7 +1,7 @@
 [world]
 name = "Provable Games"
 description = "DNC"
-seed = "test_ls_0_6"
+seed = "DNC"
 
 [env]
 rpc_url = "https://api.cartridge.gg/x/starknet/sepolia"

--- a/contracts/dojo_sepolia.toml
+++ b/contracts/dojo_sepolia.toml
@@ -5,7 +5,7 @@ seed = "DNC"
 
 [env]
 rpc_url = "https://api.cartridge.gg/x/starknet/sepolia"
-world_address = "0x3640d513d1d398f3221adcc7b038fcd3a875e85cce31014897337b7f0d0be6e"
+world_address = "0x29f11cefb67df8a3962ba60816800ccf196f9497ae781bb4bc8589f8e245753"
 
 [namespace]
 default = "ls_0_0_5"
@@ -22,5 +22,5 @@ default = "ls_0_0_5"
 [init_call_args]
 "ls_0_0_5-game_token_systems" = [
     "0x065d2AB17338b5AffdEbAF95E2D79834B5f30Bac596fF55563c62C3c98700150", # account address
-    "0x05e0f818f368a6bc04e923541477181d6e47044549fc6f4eb0fb4c8d7da373a9" # denshokan address
+    "0x06a1102ed881e0d6d689295db5819dd1d15f0d55cbe10e1b87587c2ea1ec8da4" # denshokan address
 ]

--- a/contracts/dojo_sepolia.toml
+++ b/contracts/dojo_sepolia.toml
@@ -6,8 +6,6 @@ seed = "DNC"
 [env]
 rpc_url = "https://api.cartridge.gg/x/starknet/sepolia"
 world_address = "0x38f6eb0186dfd1e072fa3b289b88e1c67b0baf1bd76cc6987f4a93258c69c4d"
-account_address = "0x065d2AB17338b5AffdEbAF95E2D79834B5f30Bac596fF55563c62C3c98700150"
-private_key = "0x0625adf89082edbffac775d64e9a5bba11483f6ef97c0925fb0433cb79d88581"
 
 [namespace]
 default = "ls_0_0_5"

--- a/contracts/dojo_sepolia.toml
+++ b/contracts/dojo_sepolia.toml
@@ -5,7 +5,7 @@ seed = "DNC"
 
 [env]
 rpc_url = "https://api.cartridge.gg/x/starknet/sepolia"
-world_address = "0x38f6eb0186dfd1e072fa3b289b88e1c67b0baf1bd76cc6987f4a93258c69c4d"
+world_address = "0x3640d513d1d398f3221adcc7b038fcd3a875e85cce31014897337b7f0d0be6e"
 
 [namespace]
 default = "ls_0_0_5"
@@ -21,6 +21,6 @@ default = "ls_0_0_5"
 
 [init_call_args]
 "ls_0_0_5-game_token_systems" = [
-    "0x065d2AB17338b5AffdEbAF95E2D79834B5f30Bac596fF55563c62C3c98700150",
-    "0x01fd7f186c0bb99f8d128f1eb40dbe3c7657df381957417f8c9a40804c005545" # denshokan_address
+    "0x065d2AB17338b5AffdEbAF95E2D79834B5f30Bac596fF55563c62C3c98700150", # account address
+    "0x05e0f818f368a6bc04e923541477181d6e47044549fc6f4eb0fb4c8d7da373a9" # denshokan address
 ]

--- a/contracts/manifest_sepolia.json
+++ b/contracts/manifest_sepolia.json
@@ -3153,7 +3153,7 @@
     },
     {
       "address": "0x39d9adb951d94086d6a25d430a58391c7951f2e1e5fa37db0394a5a256002a7",
-      "class_hash": "0x70cf2ee3812c7d78b2fa1efff497376927b1d6b41d4124a2abbf1e8508d0184",
+      "class_hash": "0x56cd9da765d0bf4342c6d2ddd14716cdbae39ff701987f40e0f04dd40f15b70",
       "abi": [
         {
           "type": "impl",

--- a/contracts/manifest_sepolia.json
+++ b/contracts/manifest_sepolia.json
@@ -5048,7 +5048,7 @@
     },
     {
       "address": "0x512c2a8ddb6e9b4d2d4e0c7a3a7aa98022dc511589ee1be5035b863267a1496",
-      "class_hash": "0x582636c4ef6a36a3fd8189e49358192406c3c86988cc2b006d379cd211b1125",
+      "class_hash": "0x6422f872b8709ab4736e950bf6a85d093f9a4868d14fe33677912e2ee957813",
       "abi": [
         {
           "type": "impl",

--- a/contracts/manifest_sepolia.json
+++ b/contracts/manifest_sepolia.json
@@ -1,7 +1,7 @@
 {
   "world": {
     "class_hash": "0x685ed02eefa98fe7e208aa295042e9bbad8029b0d3d6f0ba2b32546efe0a1f9",
-    "address": "0x3640d513d1d398f3221adcc7b038fcd3a875e85cce31014897337b7f0d0be6e",
+    "address": "0x29f11cefb67df8a3962ba60816800ccf196f9497ae781bb4bc8589f8e245753",
     "seed": "DNC",
     "name": "Provable Games",
     "entrypoints": [
@@ -1328,7 +1328,7 @@
   },
   "contracts": [
     {
-      "address": "0x61f4d906946b1000a075110590f41abde04bc7cd40b2562c8684e42428b4427",
+      "address": "0x20fd21d6bfce809959f266e427244ebc4e6470fb41324608cab460085245c72",
       "class_hash": "0x5acc9993f40b542e4fc167a5ace9047dc2776fc36f1a07b966e0142388a0edb",
       "abi": [
         {
@@ -2442,7 +2442,7 @@
       ]
     },
     {
-      "address": "0x577a012c28c1dc01e9ac4a2c56a38d03913f66a083f04c569aaec193564d8d1",
+      "address": "0x53436827646567f4a6137ac91f7603ee98a52eacda32fe59c601a48344fb4d0",
       "class_hash": "0x7406e9437f9b405c8152eb138b61818e66ce4f8a7526a22902e6fe631c75566",
       "abi": [
         {
@@ -3152,7 +3152,7 @@
       ]
     },
     {
-      "address": "0x3554d442963d196e4ea7d66ebc9232c8cb7d851288d0850b6197d5844f1c59f",
+      "address": "0x89e0eccd76c3a7acc221f008ce5eff5fb067e86c1a37be06d2ff201ee4cd4a",
       "class_hash": "0x56cd9da765d0bf4342c6d2ddd14716cdbae39ff701987f40e0f04dd40f15b70",
       "abi": [
         {
@@ -3541,7 +3541,7 @@
       ]
     },
     {
-      "address": "0x51f93d0200780270f0ca791eb36700d8aaf1c888da0635ec7abcc897e32aff3",
+      "address": "0x5eecb8d59907fb3bbc44a6618e4f5b7a7d9e8dcfcb8eaa7d64dd32ef8260aaf",
       "class_hash": "0x54fbd3cc638c4ba0ba84d4101ae88e03c89e6998badd412f3c7eff45d106814",
       "abi": [
         {
@@ -4199,7 +4199,7 @@
       ],
       "init_calldata": [
         "0x065d2AB17338b5AffdEbAF95E2D79834B5f30Bac596fF55563c62C3c98700150",
-        "0x05e0f818f368a6bc04e923541477181d6e47044549fc6f4eb0fb4c8d7da373a9"
+        "0x06a1102ed881e0d6d689295db5819dd1d15f0d55cbe10e1b87587c2ea1ec8da4"
       ],
       "tag": "ls_0_0_5-game_token_systems",
       "selector": "0x56361f0ad3f6ec1de7434cf73b2338cbd47a310909ba2d7a0df86640b561982",
@@ -4211,7 +4211,7 @@
       ]
     },
     {
-      "address": "0x5a29a56d2c898daaff58c7c3bdaabb1e94da53f5a08fddd87ea69c596f80bad",
+      "address": "0x775b72184867dc97ecd399c1dfec3d60822408f352b8ff4ccb3d967a400f07e",
       "class_hash": "0x23cdb494302994de197966707c72df5708f2516f5205ed398dacb4c16fc4bcc",
       "abi": [
         {
@@ -4718,7 +4718,7 @@
       ]
     },
     {
-      "address": "0x7d1b268d3005104cda0bd09b9c2d091d4de8485951319f27785939b4ddcd490",
+      "address": "0x1776642194d3b29859e6e309314ac6e4888ba56d67954b9d6e5db65e4427650",
       "class_hash": "0x4b68cbca8f4e749e2f0e2be0e911c3d6101e0966fc4796447b48fc468cc518d",
       "abi": [
         {
@@ -5047,7 +5047,7 @@
       ]
     },
     {
-      "address": "0x746c0e710592726b5e933ebcbcc8b1f006ca6a9024608d0c1788f7841f24df8",
+      "address": "0x3b8c69c6e3c405ec645bf977aca95b2d2978fe50632806ce4c2f4ce38aa5797",
       "class_hash": "0x6422f872b8709ab4736e950bf6a85d093f9a4868d14fe33677912e2ee957813",
       "abi": [
         {

--- a/contracts/manifest_sepolia.json
+++ b/contracts/manifest_sepolia.json
@@ -2,7 +2,7 @@
   "world": {
     "class_hash": "0x685ed02eefa98fe7e208aa295042e9bbad8029b0d3d6f0ba2b32546efe0a1f9",
     "address": "0x38f6eb0186dfd1e072fa3b289b88e1c67b0baf1bd76cc6987f4a93258c69c4d",
-    "seed": "test_ls_0_6",
+    "seed": "DNC",
     "name": "Provable Games",
     "entrypoints": [
       "uuid",

--- a/contracts/manifest_sepolia.json
+++ b/contracts/manifest_sepolia.json
@@ -1328,8 +1328,8 @@
   },
   "contracts": [
     {
-      "address": "0x6492209fe1a4e397c335fd7b9d6a6f2e5beae22e14443134c1aa4eb755f3fce",
-      "class_hash": "0x669e762330ce8a0f987d2297bdab88c2840bf4b518e41ea1afed834402125b5",
+      "address": "0x7cb86dc3a492d4e2db3afee800d9481ab862c67fc15f98bab4817de8370f2f7",
+      "class_hash": "0x5acc9993f40b542e4fc167a5ace9047dc2776fc36f1a07b966e0142388a0edb",
       "abi": [
         {
           "type": "impl",
@@ -1889,20 +1889,6 @@
           ]
         },
         {
-          "type": "enum",
-          "name": "death_mountain::models::game_data::DataResult::<core::integer::u8>",
-          "variants": [
-            {
-              "name": "Ok",
-              "type": "core::integer::u8"
-            },
-            {
-              "name": "Err",
-              "type": "core::felt252"
-            }
-          ]
-        },
-        {
           "type": "struct",
           "name": "death_mountain::models::game::AdventurerEntropy",
           "members": [
@@ -2008,6 +1994,38 @@
             },
             {
               "type": "function",
+              "name": "get_adventurer_level",
+              "inputs": [
+                {
+                  "name": "adventurer_id",
+                  "type": "core::integer::u64"
+                }
+              ],
+              "outputs": [
+                {
+                  "type": "core::integer::u8"
+                }
+              ],
+              "state_mutability": "view"
+            },
+            {
+              "type": "function",
+              "name": "get_adventurer_dungeon",
+              "inputs": [
+                {
+                  "name": "adventurer_id",
+                  "type": "core::integer::u64"
+                }
+              ],
+              "outputs": [
+                {
+                  "type": "core::starknet::contract_address::ContractAddress"
+                }
+              ],
+              "state_mutability": "view"
+            },
+            {
+              "type": "function",
               "name": "get_adventurer_verbose",
               "inputs": [
                 {
@@ -2018,26 +2036,6 @@
               "outputs": [
                 {
                   "type": "death_mountain::models::adventurer::adventurer::AdventurerVerbose"
-                }
-              ],
-              "state_mutability": "view"
-            },
-            {
-              "type": "function",
-              "name": "get_adventurer_level",
-              "inputs": [
-                {
-                  "name": "dungeon",
-                  "type": "core::starknet::contract_address::ContractAddress"
-                },
-                {
-                  "name": "adventurer_id",
-                  "type": "core::integer::u64"
-                }
-              ],
-              "outputs": [
-                {
-                  "type": "death_mountain::models::game_data::DataResult::<core::integer::u8>"
                 }
               ],
               "state_mutability": "view"
@@ -2299,8 +2297,16 @@
               "name": "get_market",
               "inputs": [
                 {
+                  "name": "adventurer_id",
+                  "type": "core::integer::u64"
+                },
+                {
                   "name": "seed",
                   "type": "core::integer::u64"
+                },
+                {
+                  "name": "market_size",
+                  "type": "core::integer::u8"
                 }
               ],
               "outputs": [
@@ -2428,16 +2434,16 @@
         }
       ],
       "init_calldata": [],
-      "tag": "ls_0_0_3-adventurer_systems",
-      "selector": "0x1ca95f88072b2ffb7b4025757a14219e7fe8424918ae3bbb0515f980385054b",
+      "tag": "ls_0_0_5-adventurer_systems",
+      "selector": "0x7d0fbab04f93dc32d8c022670b89c782800cb6be84b21c73ff90985924edd52",
       "systems": [
         "record_item_drop",
         "upgrade"
       ]
     },
     {
-      "address": "0x4b7bebdc0d2417c4a54274b4220e9ae96d697a69b04c1fb282af231759088d4",
-      "class_hash": "0x7858ae933c1e86700460ea53f1b94ccf024040bb17e1093a17bb2b83a016867",
+      "address": "0x324d04ce74e00989db72d7fed1d2efd659f8b8f7f227050a7971e187ffc2f7",
+      "class_hash": "0x7406e9437f9b405c8152eb138b61818e66ce4f8a7526a22902e6fe631c75566",
       "abi": [
         {
           "type": "impl",
@@ -2550,6 +2556,10 @@
             },
             {
               "name": "killed_by",
+              "type": "core::integer::u64"
+            },
+            {
+              "name": "timestamp",
               "type": "core::integer::u64"
             }
           ]
@@ -3132,8 +3142,8 @@
         }
       ],
       "init_calldata": [],
-      "tag": "ls_0_0_3-beast_systems",
-      "selector": "0x109eca3273715c8b45ebc03ff4ebab910f5fd47787fe7a979eef82916712824",
+      "tag": "ls_0_0_5-beast_systems",
+      "selector": "0x38a8eeefb7859f38ba7f27d4161f012f04688488377ec0cc1def3a7d7af42c3",
       "systems": [
         "add_collectable",
         "add_kill",
@@ -3142,8 +3152,8 @@
       ]
     },
     {
-      "address": "0x5b283c0108fdaa842bd5543fc67f540cce022180311eca67139d4fb5d3780a5",
-      "class_hash": "0xec64a7ecf09e11d6dacb87b30a1f84935f42faa44d9835180503ec95dbdf35",
+      "address": "0x39d9adb951d94086d6a25d430a58391c7951f2e1e5fa37db0394a5a256002a7",
+      "class_hash": "0x70cf2ee3812c7d78b2fa1efff497376927b1d6b41d4124a2abbf1e8508d0184",
       "abi": [
         {
           "type": "impl",
@@ -3516,8 +3526,8 @@
         }
       ],
       "init_calldata": [],
-      "tag": "ls_0_0_3-game_systems",
-      "selector": "0x6e6d2c18e991b0dd44d9d7c4929f7f7ba616cc481020fa1cf37ce500b2af67b",
+      "tag": "ls_0_0_5-game_systems",
+      "selector": "0x7f39beb2acb5a3124d98601d40acad8d4263ee9f4e0915fbf5c0dce1c76358e",
       "systems": [
         "start_game",
         "explore",
@@ -3531,8 +3541,8 @@
       ]
     },
     {
-      "address": "0x4dc9a55b49fea275851b31df48af9fadcc6512b486f04a4034cfdc5afbea02f",
-      "class_hash": "0x2456c3c56620a8abf78601c3dd619f7c288ed1f795357a4fdcaf9f9d873f99c",
+      "address": "0x5111300a337dfb892fda7e594a80c229f239caf0f337dc864b681b9a77555b7",
+      "class_hash": "0x54fbd3cc638c4ba0ba84d4101ae88e03c89e6998badd412f3c7eff45d106814",
       "abi": [
         {
           "type": "impl",
@@ -3750,189 +3760,9 @@
           "interface_name": "death_mountain::systems::game_token::contracts::IGameTokenSystems"
         },
         {
-          "type": "struct",
-          "name": "death_mountain::models::market::ItemPurchase",
-          "members": [
-            {
-              "name": "item_id",
-              "type": "core::integer::u8"
-            },
-            {
-              "name": "equip",
-              "type": "core::bool"
-            }
-          ]
-        },
-        {
-          "type": "struct",
-          "name": "death_mountain::models::adventurer::stats::Stats",
-          "members": [
-            {
-              "name": "strength",
-              "type": "core::integer::u8"
-            },
-            {
-              "name": "dexterity",
-              "type": "core::integer::u8"
-            },
-            {
-              "name": "vitality",
-              "type": "core::integer::u8"
-            },
-            {
-              "name": "intelligence",
-              "type": "core::integer::u8"
-            },
-            {
-              "name": "wisdom",
-              "type": "core::integer::u8"
-            },
-            {
-              "name": "charisma",
-              "type": "core::integer::u8"
-            },
-            {
-              "name": "luck",
-              "type": "core::integer::u8"
-            }
-          ]
-        },
-        {
           "type": "interface",
           "name": "death_mountain::systems::game_token::contracts::IGameTokenSystems",
           "items": [
-            {
-              "type": "function",
-              "name": "start_game",
-              "inputs": [
-                {
-                  "name": "adventurer_id",
-                  "type": "core::integer::u64"
-                },
-                {
-                  "name": "weapon",
-                  "type": "core::integer::u8"
-                }
-              ],
-              "outputs": [],
-              "state_mutability": "external"
-            },
-            {
-              "type": "function",
-              "name": "explore",
-              "inputs": [
-                {
-                  "name": "adventurer_id",
-                  "type": "core::integer::u64"
-                },
-                {
-                  "name": "till_beast",
-                  "type": "core::bool"
-                }
-              ],
-              "outputs": [],
-              "state_mutability": "external"
-            },
-            {
-              "type": "function",
-              "name": "attack",
-              "inputs": [
-                {
-                  "name": "adventurer_id",
-                  "type": "core::integer::u64"
-                },
-                {
-                  "name": "to_the_death",
-                  "type": "core::bool"
-                }
-              ],
-              "outputs": [],
-              "state_mutability": "external"
-            },
-            {
-              "type": "function",
-              "name": "flee",
-              "inputs": [
-                {
-                  "name": "adventurer_id",
-                  "type": "core::integer::u64"
-                },
-                {
-                  "name": "to_the_death",
-                  "type": "core::bool"
-                }
-              ],
-              "outputs": [],
-              "state_mutability": "external"
-            },
-            {
-              "type": "function",
-              "name": "equip",
-              "inputs": [
-                {
-                  "name": "adventurer_id",
-                  "type": "core::integer::u64"
-                },
-                {
-                  "name": "items",
-                  "type": "core::array::Array::<core::integer::u8>"
-                }
-              ],
-              "outputs": [],
-              "state_mutability": "external"
-            },
-            {
-              "type": "function",
-              "name": "drop",
-              "inputs": [
-                {
-                  "name": "adventurer_id",
-                  "type": "core::integer::u64"
-                },
-                {
-                  "name": "items",
-                  "type": "core::array::Array::<core::integer::u8>"
-                }
-              ],
-              "outputs": [],
-              "state_mutability": "external"
-            },
-            {
-              "type": "function",
-              "name": "buy_items",
-              "inputs": [
-                {
-                  "name": "adventurer_id",
-                  "type": "core::integer::u64"
-                },
-                {
-                  "name": "potions",
-                  "type": "core::integer::u8"
-                },
-                {
-                  "name": "items",
-                  "type": "core::array::Array::<death_mountain::models::market::ItemPurchase>"
-                }
-              ],
-              "outputs": [],
-              "state_mutability": "external"
-            },
-            {
-              "type": "function",
-              "name": "select_stat_upgrades",
-              "inputs": [
-                {
-                  "name": "adventurer_id",
-                  "type": "core::integer::u64"
-                },
-                {
-                  "name": "stat_upgrades",
-                  "type": "death_mountain::models::adventurer::stats::Stats"
-                }
-              ],
-              "outputs": [],
-              "state_mutability": "external"
-            },
             {
               "type": "function",
               "name": "create_objective",
@@ -4371,25 +4201,17 @@
         "0x065d2AB17338b5AffdEbAF95E2D79834B5f30Bac596fF55563c62C3c98700150",
         "0x01fd7f186c0bb99f8d128f1eb40dbe3c7657df381957417f8c9a40804c005545"
       ],
-      "tag": "ls_0_0_3-game_token_systems",
-      "selector": "0x4cc8e289ab4f6b9bdea32ac2b3428c84c3ae431519428363cc12341b1e4a188",
+      "tag": "ls_0_0_5-game_token_systems",
+      "selector": "0x56361f0ad3f6ec1de7434cf73b2338cbd47a310909ba2d7a0df86640b561982",
       "systems": [
         "dojo_init",
-        "start_game",
-        "explore",
-        "attack",
-        "flee",
-        "equip",
-        "drop",
-        "buy_items",
-        "select_stat_upgrades",
         "create_objective",
         "player_name",
         "upgrade"
       ]
     },
     {
-      "address": "0x217b739b2ddf3c485b4ba83761c0be73eb8ce13ee689c72685501939aadd27c",
+      "address": "0x301e2400c9eb8c84c576506c890721537ca0960a73c75d42943a0965aa789ae",
       "class_hash": "0x23cdb494302994de197966707c72df5708f2516f5205ed398dacb4c16fc4bcc",
       "abi": [
         {
@@ -4889,15 +4711,15 @@
         }
       ],
       "init_calldata": [],
-      "tag": "ls_0_0_3-loot_systems",
-      "selector": "0x10079fb36ed6fa91c27a5b79eba43f61bb6705b2b41825788951d184e152692",
+      "tag": "ls_0_0_5-loot_systems",
+      "selector": "0x2b044fad5c186f2ed66b548cbd7f3e7b80fd69b2c9b54f35723dc1a7d842220",
       "systems": [
         "upgrade"
       ]
     },
     {
-      "address": "0x4528a0b81efeb6b5badedb2f00713d5dc883918183c5797ae3b88650d8105e7",
-      "class_hash": "0x2706de1bd3ecbd81bea176d7215c9161393e2f0ea2db2319651d3a3a1b2522",
+      "address": "0x50f184a01e87d86e74f45106b42393bfce31f1cfc7e99585b678110774307dd",
+      "class_hash": "0x4b68cbca8f4e749e2f0e2be0e911c3d6101e0966fc4796447b48fc468cc518d",
       "abi": [
         {
           "type": "impl",
@@ -5218,15 +5040,15 @@
         }
       ],
       "init_calldata": [],
-      "tag": "ls_0_0_3-renderer_systems",
-      "selector": "0x392780804badb341aa4008518aad1229a075606089d4240a047100076445f04",
+      "tag": "ls_0_0_5-renderer_systems",
+      "selector": "0x63442767376095efb200e063d409c0df9490ba41c6bce2c65588cf27a92a809",
       "systems": [
         "upgrade"
       ]
     },
     {
-      "address": "0x60c1e9d21c5c056e9f1e2dfafff1e9d6bf62ae6c4b34176534334a1650645d1",
-      "class_hash": "0x4c76ddc85c17af3195c9e385e8360fe07c79dd4530ffc49fec4df9b469a2968",
+      "address": "0x512c2a8ddb6e9b4d2d4e0c7a3a7aa98022dc511589ee1be5035b863267a1496",
+      "class_hash": "0x582636c4ef6a36a3fd8189e49358192406c3c86988cc2b006d379cd211b1125",
       "abi": [
         {
           "type": "impl",
@@ -5640,6 +5462,10 @@
             {
               "name": "base_damage_reduction",
               "type": "core::integer::u8"
+            },
+            {
+              "name": "market_size",
+              "type": "core::integer::u8"
             }
           ]
         },
@@ -5689,6 +5515,10 @@
                 },
                 {
                   "name": "base_damage_reduction",
+                  "type": "core::integer::u8"
+                },
+                {
+                  "name": "market_size",
                   "type": "core::integer::u8"
                 }
               ],
@@ -5902,8 +5732,8 @@
         }
       ],
       "init_calldata": [],
-      "tag": "ls_0_0_3-settings_systems",
-      "selector": "0x2254d45023f5ef42fea645233c31178dd5d52f4f4e565b8271891a9939842d9",
+      "tag": "ls_0_0_5-settings_systems",
+      "selector": "0x445e9e22a3d6100fa49205e08c0f7ecb4faf2d3264f0ffc034ba2ca23ba4eb2",
       "systems": [
         "dojo_init",
         "add_settings",
@@ -5916,88 +5746,88 @@
     {
       "members": [],
       "class_hash": "0x771a18fa631c8bf12e2b85cdf510b9b59959655090027883b18100641a08497",
-      "tag": "ls_0_0_3-AdventurerEntropy",
-      "selector": "0x61684060a1f4b5960652d3b83b68bbe4e900cd1d92d94968f7800bb9b7e9350"
+      "tag": "ls_0_0_5-AdventurerEntropy",
+      "selector": "0x4e0ea8620e0cfb76e65e15dabca6a154d41cb9e5dce590c1cb942920ac8e500"
     },
     {
       "members": [],
       "class_hash": "0x7271344d76037ef2c0e6e8156b7dfa7c7b40dfc566b99f9770c99b14cb70e5b",
-      "tag": "ls_0_0_3-AdventurerKilled",
-      "selector": "0x190bbbc038c88a60dc5a91e98a38aaae4645e88a481152ecf6eb89353c11a02"
+      "tag": "ls_0_0_5-AdventurerKilled",
+      "selector": "0x16c5555af92a4eafb1f010711d8ad96e92d6d385e494ec6aebcb7a9af7b69a3"
     },
     {
       "members": [],
       "class_hash": "0x33b8218ffef53844194e5bc510edfa023441c8284a0254b002742509af88449",
-      "tag": "ls_0_0_3-AdventurerPacked",
-      "selector": "0x409e48c5486428ea3a9571967c5b481d18dad18afde48a0e0dbeea45c1a6119"
+      "tag": "ls_0_0_5-AdventurerPacked",
+      "selector": "0xd218787f47741c532120b495ece65e32fdd00dbcaa86e12c111e9d72a05e56"
     },
     {
       "members": [],
       "class_hash": "0x283ab5cc1ee44d8476f367faf47184901b144bfbc36740491a5a96dbb950599",
-      "tag": "ls_0_0_3-BagPacked",
-      "selector": "0x66d61069c5c6e6d3ce5c9a681935a371f7bff3ddf295fca016efef28716b130"
+      "tag": "ls_0_0_5-BagPacked",
+      "selector": "0x9b4f5d85571e8dc91b3625c448df17717f7e69fba4982e821a38938e51c898"
     },
     {
       "members": [],
       "class_hash": "0x3f58ca824d6b406472a58004a59fedc42889bb3b46220766b10e4e2f004e5b6",
-      "tag": "ls_0_0_3-CollectableCount",
-      "selector": "0x7bae3d49ae4c6f939d927afdc02ff751da95bd19174dc8f12d53fe8a9273c2d"
+      "tag": "ls_0_0_5-CollectableCount",
+      "selector": "0x7bad0b29da2a18fef41ed4871e85cdbd051185b9d8aef8baa82ca96957ab01d"
     },
     {
       "members": [],
-      "class_hash": "0x6f72223ce0d9079f149abbe4f512cef0718c37129167cb3dbd5835841784b3a",
-      "tag": "ls_0_0_3-CollectableEntity",
-      "selector": "0x72c29215eaf728cf41f65097ed6931b15851f537c4e4b7740e22e89372a8726"
+      "class_hash": "0x603d0d6568096654bbabaa2f1494a497f3060fa3c03882823cea468c8b9bf94",
+      "tag": "ls_0_0_5-CollectableEntity",
+      "selector": "0x73482c675d080bac6d6ac51ffe2dfb50c875281fbe83fa0ac66be5df93e23cc"
     },
     {
       "members": [],
       "class_hash": "0x1574c394faebc84b15fd5e43414a47ac257ebadb3683775d4df7998bdfdc840",
-      "tag": "ls_0_0_3-DroppedItem",
-      "selector": "0x3c8e2abb4f0cace0aefd252d0d7df477e0a98f1f8077aa2bc263ba7e7278cf5"
+      "tag": "ls_0_0_5-DroppedItem",
+      "selector": "0x706cd23a322dca735ff16f9bf339f8f3412a822a4da7534edb38f109c410d57"
     },
     {
       "members": [],
       "class_hash": "0x654e3dcfe40ee0d8a3e2d17a448f8208a2515316b9573629ef9ebb038ae2fda",
-      "tag": "ls_0_0_3-EntityStats",
-      "selector": "0x2811e1508fb872e0e63b19e23eca902ea1758fc19a2fe0bbc53d4d4c479b2cb"
+      "tag": "ls_0_0_5-EntityStats",
+      "selector": "0x27f5cd07772517d4fd6433e0e8bb1b95c119bc3d47ad060516dd5e52d59c11d"
     },
     {
       "members": [],
-      "class_hash": "0x79210d657508115b5ed81b30ab50889a4fcd56266f646e17733b877cbc1fb36",
-      "tag": "ls_0_0_3-GameSettings",
-      "selector": "0x274b96fd70f18eba1d682d55fc31289caa91ba6f19b92c3f7ae31e4a272b11a"
+      "class_hash": "0x60334ed79ffe3bb44f5331aa432014a9df104683769da7a4ad6dab9e23630fb",
+      "tag": "ls_0_0_5-GameSettings",
+      "selector": "0x207a8c2a70cd16fa38f2a3e019b16a441e18d017147bc5061f4192f4e4c1f25"
     },
     {
       "members": [],
       "class_hash": "0x42467a73ead2a48a5d522d48d5ca6fa81a6a5b1377b6b8f0e32c3b0f4c0c8b6",
-      "tag": "ls_0_0_3-GameSettingsMetadata",
-      "selector": "0x7544994f840a8e3ef7592b4c863e124c02d76dd7149c23f2569b5df812a39bd"
+      "tag": "ls_0_0_5-GameSettingsMetadata",
+      "selector": "0x5ae772d27011510ec2ed5df181c7e368c5ee662cf52d8408d1b6b00d28d6e17"
     },
     {
       "members": [],
       "class_hash": "0x2aa835e634c1a8ff12a13e1f1e8592a1f9efcfb61f048e8907a7b4e29656930",
-      "tag": "ls_0_0_3-ScoreObjective",
-      "selector": "0x40d937c19191bf178df18b746de58721794c7c6a81e57c8a249bf4fff770842"
+      "tag": "ls_0_0_5-ScoreObjective",
+      "selector": "0x325fddc6889b22ed2aeb58e663a880ada247603054e6eb789937a5e30023a41"
     },
     {
       "members": [],
       "class_hash": "0x5ece982bfe94084959dcedbf5a4474810aeeef714cc4bb2ef78248aa36dd9e4",
-      "tag": "ls_0_0_3-ScoreObjectiveCount",
-      "selector": "0x39e7bc23658680ced3e82a2544c3418953e2fb8c98066c185be6de9f1b95ae2"
+      "tag": "ls_0_0_5-ScoreObjectiveCount",
+      "selector": "0x4cfce6f8428f0a737588196b317066191ee452c87cb1badb5f3931cf31ed109"
     },
     {
       "members": [],
       "class_hash": "0x791787e562ed970a599a13e2f690391968b8f75ea0dcfc38573fc3300c6c942",
-      "tag": "ls_0_0_3-SettingsCounter",
-      "selector": "0x3ff9dfc290210c04eb55643880d68c0b9ea411fc35e44558a791e678496f94b"
+      "tag": "ls_0_0_5-SettingsCounter",
+      "selector": "0x66a540b94018310930eab07bf970cd425e484c867680d47b84d0a19e4a6ab15"
     }
   ],
   "events": [
     {
       "members": [],
       "class_hash": "0x5a3ab3a85b1c39cf5678ef7247fbec098103c4baf9f52d41632d22acce4e77d",
-      "tag": "ls_0_0_3-GameEvent",
-      "selector": "0x1660418e1f7c968e165e360b552243caad6d72b249a696cfbbea1120c8256f3"
+      "tag": "ls_0_0_5-GameEvent",
+      "selector": "0x538414346e04c62c9ac7bdf4279d2e8b02e9133f5ae1959e7a467556e593f5e"
     }
   ],
   "external_contracts": []

--- a/contracts/manifest_sepolia.json
+++ b/contracts/manifest_sepolia.json
@@ -1,7 +1,7 @@
 {
   "world": {
     "class_hash": "0x685ed02eefa98fe7e208aa295042e9bbad8029b0d3d6f0ba2b32546efe0a1f9",
-    "address": "0x38f6eb0186dfd1e072fa3b289b88e1c67b0baf1bd76cc6987f4a93258c69c4d",
+    "address": "0x3640d513d1d398f3221adcc7b038fcd3a875e85cce31014897337b7f0d0be6e",
     "seed": "DNC",
     "name": "Provable Games",
     "entrypoints": [
@@ -1328,7 +1328,7 @@
   },
   "contracts": [
     {
-      "address": "0x7cb86dc3a492d4e2db3afee800d9481ab862c67fc15f98bab4817de8370f2f7",
+      "address": "0x61f4d906946b1000a075110590f41abde04bc7cd40b2562c8684e42428b4427",
       "class_hash": "0x5acc9993f40b542e4fc167a5ace9047dc2776fc36f1a07b966e0142388a0edb",
       "abi": [
         {
@@ -2442,7 +2442,7 @@
       ]
     },
     {
-      "address": "0x324d04ce74e00989db72d7fed1d2efd659f8b8f7f227050a7971e187ffc2f7",
+      "address": "0x577a012c28c1dc01e9ac4a2c56a38d03913f66a083f04c569aaec193564d8d1",
       "class_hash": "0x7406e9437f9b405c8152eb138b61818e66ce4f8a7526a22902e6fe631c75566",
       "abi": [
         {
@@ -3152,7 +3152,7 @@
       ]
     },
     {
-      "address": "0x39d9adb951d94086d6a25d430a58391c7951f2e1e5fa37db0394a5a256002a7",
+      "address": "0x3554d442963d196e4ea7d66ebc9232c8cb7d851288d0850b6197d5844f1c59f",
       "class_hash": "0x56cd9da765d0bf4342c6d2ddd14716cdbae39ff701987f40e0f04dd40f15b70",
       "abi": [
         {
@@ -3541,7 +3541,7 @@
       ]
     },
     {
-      "address": "0x5111300a337dfb892fda7e594a80c229f239caf0f337dc864b681b9a77555b7",
+      "address": "0x51f93d0200780270f0ca791eb36700d8aaf1c888da0635ec7abcc897e32aff3",
       "class_hash": "0x54fbd3cc638c4ba0ba84d4101ae88e03c89e6998badd412f3c7eff45d106814",
       "abi": [
         {
@@ -4199,7 +4199,7 @@
       ],
       "init_calldata": [
         "0x065d2AB17338b5AffdEbAF95E2D79834B5f30Bac596fF55563c62C3c98700150",
-        "0x01fd7f186c0bb99f8d128f1eb40dbe3c7657df381957417f8c9a40804c005545"
+        "0x05e0f818f368a6bc04e923541477181d6e47044549fc6f4eb0fb4c8d7da373a9"
       ],
       "tag": "ls_0_0_5-game_token_systems",
       "selector": "0x56361f0ad3f6ec1de7434cf73b2338cbd47a310909ba2d7a0df86640b561982",
@@ -4211,7 +4211,7 @@
       ]
     },
     {
-      "address": "0x301e2400c9eb8c84c576506c890721537ca0960a73c75d42943a0965aa789ae",
+      "address": "0x5a29a56d2c898daaff58c7c3bdaabb1e94da53f5a08fddd87ea69c596f80bad",
       "class_hash": "0x23cdb494302994de197966707c72df5708f2516f5205ed398dacb4c16fc4bcc",
       "abi": [
         {
@@ -4718,7 +4718,7 @@
       ]
     },
     {
-      "address": "0x50f184a01e87d86e74f45106b42393bfce31f1cfc7e99585b678110774307dd",
+      "address": "0x7d1b268d3005104cda0bd09b9c2d091d4de8485951319f27785939b4ddcd490",
       "class_hash": "0x4b68cbca8f4e749e2f0e2be0e911c3d6101e0966fc4796447b48fc468cc518d",
       "abi": [
         {
@@ -5047,7 +5047,7 @@
       ]
     },
     {
-      "address": "0x512c2a8ddb6e9b4d2d4e0c7a3a7aa98022dc511589ee1be5035b863267a1496",
+      "address": "0x746c0e710592726b5e933ebcbcc8b1f006ca6a9024608d0c1788f7841f24df8",
       "class_hash": "0x6422f872b8709ab4736e950bf6a85d093f9a4868d14fe33677912e2ee957813",
       "abi": [
         {

--- a/contracts/scripts/deploy_sepolia.sh
+++ b/contracts/scripts/deploy_sepolia.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+# Namespace variables for easier maintenance
+LS_NAMESPACE="ls_0_0_5"
+
+#-----------------
+# build
+#
+echo "------------------------------------------------------------------------------"
+echo "Cleaning..."
+sozo clean -P sepolia
+echo "Building..."
+sozo build -P sepolia
+
+#-----------------
+# migrate
+#
+echo ">>> Migrate"
+sozo migrate -P sepolia
+echo "👍"
+
+#-----------------
+# get deployed addresses
+#
+
+export MANIFEST_FILE_PATH="./manifest_sepolia.json"
+
+get_contract_address () {
+  local TAG=$1
+  local RESULT=$(cat $MANIFEST_FILE_PATH | jq -r ".contracts[] | select(.tag == \"$TAG\" ).address")
+  if [[ -z "$RESULT" ]]; then
+    >&2 echo "get_contract_address($TAG) not found! 👎"
+  fi
+  echo $RESULT
+}
+
+export DEATH_MOUNTAIN_ADDRESS=$(get_contract_address "${LS_NAMESPACE}-game_token_systems")
+export GAME_SYSTEM_ADDRESS=$(get_contract_address "${LS_NAMESPACE}-game_systems")
+export SETTINGS_SYSTEM_ADDRESS=$(get_contract_address "${LS_NAMESPACE}-settings_systems")
+
+echo "DEATH MOUNTAIN ADDRESS: $DEATH_MOUNTAIN_ADDRESS"
+echo "GAME SYSTEMS ADDRESS: $GAME_SYSTEM_ADDRESS"
+echo "SETTINGS SYSTEMS ADDRESS: $SETTINGS_SYSTEM_ADDRESS"

--- a/contracts/src/constants/world.cairo
+++ b/contracts/src/constants/world.cairo
@@ -7,7 +7,7 @@ const KATANA_CHAIN_ID: felt252 = 0x4b4154414e41;
 pub const VERSION: felt252 = '0.0.1';
 
 pub fn DEFAULT_NS() -> ByteArray {
-    "ls_0_0_4"
+    "ls_0_0_5"
 }
 
 pub fn SCORE_MODEL() -> ByteArray {

--- a/contracts/src/systems/game/contracts.cairo
+++ b/contracts/src/systems/game/contracts.cairo
@@ -58,6 +58,8 @@ mod game_systems {
     use openzeppelin_token::erc721::interface::{IERC721Dispatcher, IERC721DispatcherTrait};
     use starknet::{ContractAddress, get_tx_info};
     use super::VRF_ENABLED;
+    use game_components_minigame::libs::{assert_token_ownership, pre_action, post_action};
+    use game_components_minigame::interface::{IMinigameDispatcher, IMinigameDispatcherTrait};
 
     // ------------------------------------------ //
     // ------------ Helper Functions ------------ //
@@ -105,6 +107,10 @@ mod game_systems {
     impl GameSystemsImpl of super::IGameSystems<ContractState> {
         fn start_game(ref self: ContractState, adventurer_id: u64, weapon: u8) {
             let mut world: WorldStorage = self.world(@DEFAULT_NS());
+
+            let token_address = _get_token_address(world);
+            assert_token_ownership(token_address, adventurer_id);
+            pre_action(token_address, adventurer_id);
 
             _assert_game_not_started(world, adventurer_id);
 
@@ -194,11 +200,18 @@ mod game_systems {
                 _save_seed(ref world, adventurer_id, market_seed, 0);
                 _save_bag(ref world, adventurer_id, adventurer.action_count, game_settings.bag, game_libs);
                 _save_adventurer(ref world, ref adventurer, game_settings.bag, adventurer_id, game_libs);
+
+                post_action(token_address, adventurer_id)
             }
         }
 
         fn explore(ref self: ContractState, adventurer_id: u64, till_beast: bool) {
             let mut world: WorldStorage = self.world(@DEFAULT_NS());
+
+            let token_address = _get_token_address(world);
+            assert_token_ownership(token_address, adventurer_id);
+            pre_action(token_address, adventurer_id);
+
             let game_libs = _init_game_context(world);
             let (mut adventurer, mut bag) = game_libs.adventurer.load_assets(adventurer_id);
             adventurer.increment_action_count();
@@ -238,10 +251,17 @@ mod game_systems {
             }
 
             _save_adventurer(ref world, ref adventurer, bag, adventurer_id, game_libs);
+
+            post_action(token_address, adventurer_id);
         }
 
         fn attack(ref self: ContractState, adventurer_id: u64, to_the_death: bool) {
             let mut world: WorldStorage = self.world(@DEFAULT_NS());
+
+            let token_address = _get_token_address(world);
+            assert_token_ownership(token_address, adventurer_id);
+            pre_action(token_address, adventurer_id);
+
             let game_libs = _init_game_context(world);
 
             let (mut adventurer, bag) = game_libs.adventurer.load_assets(adventurer_id);
@@ -321,10 +341,17 @@ mod game_systems {
             }
 
             _save_adventurer(ref world, ref adventurer, bag, adventurer_id, game_libs);
+
+            post_action(token_address, adventurer_id);
         }
 
         fn flee(ref self: ContractState, adventurer_id: u64, to_the_death: bool) {
             let mut world: WorldStorage = self.world(@DEFAULT_NS());
+
+            let token_address = _get_token_address(world);
+            assert_token_ownership(token_address, adventurer_id);
+            pre_action(token_address, adventurer_id);
+
             let game_libs = _init_game_context(world);
 
             let (mut adventurer, bag) = game_libs.adventurer.load_assets(adventurer_id);
@@ -385,10 +412,17 @@ mod game_systems {
             }
 
             _save_adventurer(ref world, ref adventurer, bag, adventurer_id, game_libs);
+
+            post_action(token_address, adventurer_id);
         }
 
         fn equip(ref self: ContractState, adventurer_id: u64, items: Array<u8>) {
             let mut world: WorldStorage = self.world(@DEFAULT_NS());
+
+            let token_address = _get_token_address(world);
+            assert_token_ownership(token_address, adventurer_id);
+            pre_action(token_address, adventurer_id);
+
             let game_libs = _init_game_context(world);
 
             let (mut adventurer, mut bag) = game_libs.adventurer.load_assets(adventurer_id);
@@ -458,10 +492,17 @@ mod game_systems {
             }
 
             _save_adventurer(ref world, ref adventurer, bag, adventurer_id, game_libs);
+
+            post_action(token_address, adventurer_id);
         }
 
         fn drop(ref self: ContractState, adventurer_id: u64, items: Array<u8>) {
             let mut world: WorldStorage = self.world(@DEFAULT_NS());
+
+            let token_address = _get_token_address(world);
+            assert_token_ownership(token_address, adventurer_id);
+            pre_action(token_address, adventurer_id);
+
             let game_libs = _init_game_context(world);
 
             let (mut adventurer, mut bag) = game_libs.adventurer.load_assets(adventurer_id);
@@ -490,10 +531,17 @@ mod game_systems {
             }
 
             _save_adventurer(ref world, ref adventurer, bag, adventurer_id, game_libs);
+
+            post_action(token_address, adventurer_id);
         }
 
         fn buy_items(ref self: ContractState, adventurer_id: u64, potions: u8, items: Array<ItemPurchase>) {
             let mut world: WorldStorage = self.world(@DEFAULT_NS());
+
+            let token_address = _get_token_address(world);
+            assert_token_ownership(token_address, adventurer_id);
+            pre_action(token_address, adventurer_id);
+
             let game_libs = _init_game_context(world);
 
             let (mut adventurer, mut bag) = game_libs.adventurer.load_assets(adventurer_id);
@@ -543,10 +591,17 @@ mod game_systems {
             );
 
             _save_adventurer(ref world, ref adventurer, bag, adventurer_id, game_libs);
+
+            post_action(token_address, adventurer_id);
         }
 
         fn select_stat_upgrades(ref self: ContractState, adventurer_id: u64, stat_upgrades: Stats) {
             let mut world: WorldStorage = self.world(@DEFAULT_NS());
+
+            let token_address = _get_token_address(world);
+            assert_token_ownership(token_address, adventurer_id);
+            pre_action(token_address, adventurer_id);
+
             let game_libs = _init_game_context(world);
 
             let (mut adventurer, bag) = game_libs.adventurer.load_assets(adventurer_id);
@@ -578,6 +633,8 @@ mod game_systems {
             );
 
             _save_adventurer(ref world, ref adventurer, bag, adventurer_id, game_libs);
+
+            post_action(token_address, adventurer_id);
         }
     }
 
@@ -1515,6 +1572,12 @@ mod game_systems {
     // ------------ Helper Functions ------------ //
     // ------------------------------------------ //
 
+    fn _get_token_address(world: WorldStorage) -> ContractAddress {
+        let (game_token_systems_address, _) = world.dns(@"game_token_systems").unwrap();
+        let minigame_dispatcher = IMinigameDispatcher { contract_address: game_token_systems_address };
+        minigame_dispatcher.token_address()
+    }
+
     fn _get_random_seed(
         adventurer_id: u64, adventurer_xp: u16, game_seed: u64, game_seed_until_xp: u16, vrf_address: ContractAddress,
     ) -> (u64, u64) {
@@ -1623,13 +1686,6 @@ mod game_systems {
         assert(stat_upgrades.luck == 0, messages::NON_ZERO_STARTING_LUCK);
     }
 
-
-    fn _assert_token_ownership(world: WorldStorage, token_id: u64) {
-        let (contract_address, _) = world.dns(@"game_token_systems").unwrap();
-        let game_token = IERC721Dispatcher { contract_address };
-        assert(game_token.owner_of(token_id.into()) == starknet::get_caller_address(), 'Not Owner');
-    }
-
     fn _assert_game_not_started(world: WorldStorage, adventurer_id: u64) {
         let game_libs = ImplGameLibs::new(world);
         let adventurer = game_libs.adventurer.get_adventurer(adventurer_id);
@@ -1669,10 +1725,8 @@ mod tests {
     use death_mountain::models::market::ItemPurchase;
     use death_mountain::systems::adventurer::contracts::{IAdventurerSystemsDispatcherTrait, adventurer_systems};
     use death_mountain::systems::beast::contracts::beast_systems;
-    use death_mountain::systems::game::contracts::{game_systems};
-    use death_mountain::systems::game_token::contracts::{
-        IGameTokenSystemsDispatcher, IGameTokenSystemsDispatcherTrait, game_token_systems,
-    };
+    use death_mountain::systems::game::contracts::{IGameSystemsDispatcher, IGameSystemsDispatcherTrait, game_systems};
+    use death_mountain::systems::game_token::contracts::game_token_systems;
     use death_mountain::systems::loot::contracts::{ILootSystemsDispatcherTrait, loot_systems};
     use death_mountain::systems::renderer::contracts::renderer_systems;
     use death_mountain::systems::settings::contracts::settings_systems;
@@ -1735,7 +1789,7 @@ mod tests {
             .span()
     }
 
-    fn deploy_dungeon() -> (WorldStorage, IGameTokenSystemsDispatcher, GameLibs, IMinigameTokenMixinDispatcher) {
+    fn deploy_dungeon() -> (WorldStorage, IGameSystemsDispatcher, GameLibs, IMinigameTokenMixinDispatcher) {
         let denshokan_contracts = death_mountain::utils::setup_denshokan::setup();
 
         let ndef = namespace_def();
@@ -1748,14 +1802,14 @@ mod tests {
         starknet::testing::set_account_contract_address(contract_address_const::<'player1'>());
         starknet::testing::set_block_timestamp(300000);
 
-        let (contract_address, _) = world.dns(@"game_token_systems").unwrap();
-        let game_systems_dispatcher = IGameTokenSystemsDispatcher { contract_address: contract_address };
+        let (contract_address, _) = world.dns(@"game_systems").unwrap();
+        let game_systems_dispatcher = IGameSystemsDispatcher { contract_address: contract_address };
 
         let game_libs = ImplGameLibs::new(world);
         (world, game_systems_dispatcher, game_libs, denshokan_contracts.denshokan)
     }
 
-    fn new_game(world: WorldStorage, game: IGameTokenSystemsDispatcher) -> u64 {
+    fn new_game(world: WorldStorage, game: IGameSystemsDispatcher) -> u64 {
         let (contract_address, _) = world.dns(@"game_token_systems").unwrap();
         let minigame_dispatcher = IMinigameDispatcher { contract_address };
 
@@ -1792,7 +1846,7 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected: ('Action not allowed in battle', 'ENTRYPOINT_FAILED', 'ENTRYPOINT_FAILED'))]
+    #[should_panic(expected: ('Action not allowed in battle', 'ENTRYPOINT_FAILED'))]
     fn no_explore_during_battle() {
         let (world, game, _, _) = deploy_dungeon();
         let adventurer_id = new_game(world, game);
@@ -1818,7 +1872,7 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected: ('Cant flee starter beast', 'ENTRYPOINT_FAILED', 'ENTRYPOINT_FAILED'))]
+    #[should_panic(expected: ('Cant flee starter beast', 'ENTRYPOINT_FAILED'))]
     fn cant_flee_starter_beast() {
         let (world, game, _, _) = deploy_dungeon();
         let adventurer_id = new_game(world, game);
@@ -1829,7 +1883,7 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected: ('Not in battle', 'ENTRYPOINT_FAILED', 'ENTRYPOINT_FAILED'))]
+    #[should_panic(expected: ('Not in battle', 'ENTRYPOINT_FAILED'))]
     fn cant_attack_outside_battle() {
         let (world, game, _, _) = deploy_dungeon();
         let adventurer_id = new_game(world, game);
@@ -1840,7 +1894,7 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected: ('Not in battle', 'ENTRYPOINT_FAILED', 'ENTRYPOINT_FAILED'))]
+    #[should_panic(expected: ('Not in battle', 'ENTRYPOINT_FAILED'))]
     fn cant_flee_outside_battle() {
         let (world, game, _, _) = deploy_dungeon();
         let adventurer_id = new_game(world, game);
@@ -1888,7 +1942,7 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected: ('Stat upgrade available', 'ENTRYPOINT_FAILED', 'ENTRYPOINT_FAILED'))]
+    #[should_panic(expected: ('Stat upgrade available', 'ENTRYPOINT_FAILED'))]
     fn explore_not_allowed_with_avail_stat_upgrade() {
         let (world, game, game_libs, _) = deploy_dungeon();
         let adventurer_id = new_game(world, game);
@@ -1909,7 +1963,7 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected: ('Action not allowed in battle', 'ENTRYPOINT_FAILED', 'ENTRYPOINT_FAILED'))]
+    #[should_panic(expected: ('Action not allowed in battle', 'ENTRYPOINT_FAILED'))]
     fn buy_items_during_battle() {
         let (world, game, _, _) = deploy_dungeon();
         let adventurer_id = new_game(world, game);
@@ -1920,7 +1974,7 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected: ('Market is closed', 'ENTRYPOINT_FAILED', 'ENTRYPOINT_FAILED'))]
+    #[should_panic(expected: ('Market is closed', 'ENTRYPOINT_FAILED'))]
     fn buy_items_with_stat_upgrades() {
         let (world, game, game_libs, _) = deploy_dungeon();
         let adventurer_id = new_game(world, game);
@@ -1942,7 +1996,7 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected: ('Item already owned', 'ENTRYPOINT_FAILED', 'ENTRYPOINT_FAILED'))]
+    #[should_panic(expected: ('Item already owned', 'ENTRYPOINT_FAILED'))]
     fn buy_duplicate_item_equipped() {
         let (world, game, game_libs, _) = deploy_dungeon();
         let adventurer_id = new_game(world, game);
@@ -1971,7 +2025,7 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected: ('Item already owned', 'ENTRYPOINT_FAILED', 'ENTRYPOINT_FAILED'))]
+    #[should_panic(expected: ('Item already owned', 'ENTRYPOINT_FAILED'))]
     fn buy_duplicate_item_bagged() {
         let (world, game, game_libs, _) = deploy_dungeon();
         let adventurer_id = new_game(world, game);
@@ -2001,7 +2055,7 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected: ('Market item does not exist', 'ENTRYPOINT_FAILED', 'ENTRYPOINT_FAILED'))]
+    #[should_panic(expected: ('Market item does not exist', 'ENTRYPOINT_FAILED'))]
     fn buy_item_not_on_market() {
         let (world, game, game_libs, _) = deploy_dungeon();
         let adventurer_id = new_game(world, game);
@@ -2143,7 +2197,7 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected: ('Item not in bag', 'ENTRYPOINT_FAILED', 'ENTRYPOINT_FAILED', 'ENTRYPOINT_FAILED'))]
+    #[should_panic(expected: ('Item not in bag', 'ENTRYPOINT_FAILED', 'ENTRYPOINT_FAILED'))]
     fn equip_not_in_bag() {
         let (world, game, _, _) = deploy_dungeon();
         let adventurer_id = new_game(world, game);
@@ -2159,7 +2213,7 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected: ('Too many items', 'ENTRYPOINT_FAILED', 'ENTRYPOINT_FAILED'))]
+    #[should_panic(expected: ('Too many items', 'ENTRYPOINT_FAILED'))]
     fn equip_too_many_items() {
         let (world, game, _, _) = deploy_dungeon();
         let adventurer_id = new_game(world, game);
@@ -2339,7 +2393,7 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected: ('Health already full', 'ENTRYPOINT_FAILED', 'ENTRYPOINT_FAILED'))]
+    #[should_panic(expected: ('Health already full', 'ENTRYPOINT_FAILED'))]
     fn buy_potions_exceed_max_health() {
         let (world, game, game_libs, _) = deploy_dungeon();
         let adventurer_id = new_game(world, game);
@@ -2372,7 +2426,7 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected: ('Market is closed', 'ENTRYPOINT_FAILED', 'ENTRYPOINT_FAILED'))]
+    #[should_panic(expected: ('Market is closed', 'ENTRYPOINT_FAILED'))]
     fn cant_buy_potion_with_stat_upgrade() {
         let (world, game, _, _) = deploy_dungeon();
         let adventurer_id = new_game(world, game);
@@ -2387,7 +2441,7 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected: ('Action not allowed in battle', 'ENTRYPOINT_FAILED', 'ENTRYPOINT_FAILED'))]
+    #[should_panic(expected: ('Action not allowed in battle', 'ENTRYPOINT_FAILED'))]
     fn cant_buy_potion_during_battle() {
         let (world, game, _, _) = deploy_dungeon();
         let adventurer_id = new_game(world, game);
@@ -2517,7 +2571,7 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected: ('insufficient stat upgrades', 'ENTRYPOINT_FAILED', 'ENTRYPOINT_FAILED'))]
+    #[should_panic(expected: ('insufficient stat upgrades', 'ENTRYPOINT_FAILED'))]
     fn upgrade_stats_not_enough_points() {
         let (world, game, _, _) = deploy_dungeon();
         let adventurer_id = new_game(world, game);
@@ -2584,7 +2638,7 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected: ('Action not allowed in battle', 'ENTRYPOINT_FAILED', 'ENTRYPOINT_FAILED'))]
+    #[should_panic(expected: ('Action not allowed in battle', 'ENTRYPOINT_FAILED'))]
     fn no_dropping_starter_weapon_during_starter_beast() {
         let (world, game, _, _) = deploy_dungeon();
         let adventurer_id = new_game(world, game);

--- a/contracts/src/systems/game/contracts.cairo
+++ b/contracts/src/systems/game/contracts.cairo
@@ -201,8 +201,8 @@ mod game_systems {
                 _save_bag(ref world, adventurer_id, adventurer.action_count, game_settings.bag, game_libs);
                 _save_adventurer(ref world, ref adventurer, game_settings.bag, adventurer_id, game_libs);
 
-                post_action(token_address, adventurer_id)
             }
+            post_action(token_address, adventurer_id)
         }
 
         fn explore(ref self: ContractState, adventurer_id: u64, till_beast: bool) {

--- a/contracts/src/systems/game/contracts.cairo
+++ b/contracts/src/systems/game/contracts.cairo
@@ -55,11 +55,11 @@ mod game_systems {
     use dojo::event::EventStorage;
     use dojo::model::ModelStorage;
     use dojo::world::{WorldStorage, WorldStorageTrait};
+    use game_components_minigame::interface::{IMinigameDispatcher, IMinigameDispatcherTrait};
+    use game_components_minigame::libs::{assert_token_ownership, post_action, pre_action};
     use openzeppelin_token::erc721::interface::{IERC721Dispatcher, IERC721DispatcherTrait};
     use starknet::{ContractAddress, get_tx_info};
     use super::VRF_ENABLED;
-    use game_components_minigame::libs::{assert_token_ownership, pre_action, post_action};
-    use game_components_minigame::interface::{IMinigameDispatcher, IMinigameDispatcherTrait};
 
     // ------------------------------------------ //
     // ------------ Helper Functions ------------ //
@@ -200,7 +200,6 @@ mod game_systems {
                 _save_seed(ref world, adventurer_id, market_seed, 0);
                 _save_bag(ref world, adventurer_id, adventurer.action_count, game_settings.bag, game_libs);
                 _save_adventurer(ref world, ref adventurer, game_settings.bag, adventurer_id, game_libs);
-
             }
             post_action(token_address, adventurer_id)
         }

--- a/contracts/src/systems/game_token/contracts.cairo
+++ b/contracts/src/systems/game_token/contracts.cairo
@@ -4,14 +4,6 @@ use death_mountain::models::market::ItemPurchase;
 
 #[starknet::interface]
 pub trait IGameTokenSystems<T> {
-    fn start_game(ref self: T, adventurer_id: u64, weapon: u8);
-    fn explore(ref self: T, adventurer_id: u64, till_beast: bool);
-    fn attack(ref self: T, adventurer_id: u64, to_the_death: bool);
-    fn flee(ref self: T, adventurer_id: u64, to_the_death: bool);
-    fn equip(ref self: T, adventurer_id: u64, items: Array<u8>);
-    fn drop(ref self: T, adventurer_id: u64, items: Array<u8>);
-    fn buy_items(ref self: T, adventurer_id: u64, potions: u8, items: Array<ItemPurchase>);
-    fn select_stat_upgrades(ref self: T, adventurer_id: u64, stat_upgrades: Stats);
     fn create_objective(ref self: T, score: u32);
     fn player_name(ref self: T, adventurer_id: u64) -> ByteArray;
 }
@@ -39,7 +31,7 @@ mod game_token_systems {
     use game_components_minigame::minigame::MinigameComponent;
 
     use openzeppelin_introspection::src5::SRC5Component;
-    use starknet::ContractAddress;
+    use starknet::{ContractAddress, get_contract_address};
 
     // Components
     component!(path: MinigameComponent, storage: minigame, event: MinigameEvent);
@@ -100,7 +92,7 @@ mod game_token_systems {
                 Option::None, // client_url
                 Option::Some(renderer_address), // renderer address
                 Option::Some(settings_systems_address), // settings_address
-                Option::None, // objectives_address
+                Option::Some(get_contract_address()), // objectives_address
                 denshokan_address,
             );
 
@@ -191,79 +183,6 @@ mod game_token_systems {
     // ------------------------------------------ //
     #[abi(embed_v0)]
     impl GameTokenSystemsImpl of super::IGameTokenSystems<ContractState> {
-        fn start_game(ref self: ContractState, adventurer_id: u64, weapon: u8) {
-            let mut world: WorldStorage = self.world(@DEFAULT_NS());
-            self.minigame.pre_action(adventurer_id);
-            let (game_systems_address, _) = world.dns(@"game_systems").unwrap();
-            let game_systems = IGameSystemsDispatcher { contract_address: game_systems_address };
-            game_systems.start_game(adventurer_id, weapon);
-            self.minigame.post_action(adventurer_id);
-        }
-
-        fn explore(ref self: ContractState, adventurer_id: u64, till_beast: bool) {
-            let mut world: WorldStorage = self.world(@DEFAULT_NS());
-            self.minigame.pre_action(adventurer_id);
-            let (game_systems_address, _) = world.dns(@"game_systems").unwrap();
-            let game_systems = IGameSystemsDispatcher { contract_address: game_systems_address };
-            game_systems.explore(adventurer_id, till_beast);
-            self.minigame.post_action(adventurer_id);
-        }
-
-
-        fn attack(ref self: ContractState, adventurer_id: u64, to_the_death: bool) {
-            let mut world: WorldStorage = self.world(@DEFAULT_NS());
-            self.minigame.pre_action(adventurer_id);
-            let (game_systems_address, _) = world.dns(@"game_systems").unwrap();
-            let game_systems = IGameSystemsDispatcher { contract_address: game_systems_address };
-            game_systems.attack(adventurer_id, to_the_death);
-            self.minigame.post_action(adventurer_id);
-        }
-
-        fn flee(ref self: ContractState, adventurer_id: u64, to_the_death: bool) {
-            let mut world: WorldStorage = self.world(@DEFAULT_NS());
-            self.minigame.pre_action(adventurer_id);
-            let (game_systems_address, _) = world.dns(@"game_systems").unwrap();
-            let game_systems = IGameSystemsDispatcher { contract_address: game_systems_address };
-            game_systems.flee(adventurer_id, to_the_death);
-            self.minigame.post_action(adventurer_id);
-        }
-
-        fn equip(ref self: ContractState, adventurer_id: u64, items: Array<u8>) {
-            let mut world: WorldStorage = self.world(@DEFAULT_NS());
-            self.minigame.pre_action(adventurer_id);
-            let (game_systems_address, _) = world.dns(@"game_systems").unwrap();
-            let game_systems = IGameSystemsDispatcher { contract_address: game_systems_address };
-            game_systems.equip(adventurer_id, items);
-            self.minigame.post_action(adventurer_id);
-        }
-
-        fn drop(ref self: ContractState, adventurer_id: u64, items: Array<u8>) {
-            let mut world: WorldStorage = self.world(@DEFAULT_NS());
-            self.minigame.pre_action(adventurer_id);
-            let (game_systems_address, _) = world.dns(@"game_systems").unwrap();
-            let game_systems = IGameSystemsDispatcher { contract_address: game_systems_address };
-            game_systems.drop(adventurer_id, items);
-            self.minigame.post_action(adventurer_id);
-        }
-
-        fn buy_items(ref self: ContractState, adventurer_id: u64, potions: u8, items: Array<ItemPurchase>) {
-            let mut world: WorldStorage = self.world(@DEFAULT_NS());
-            self.minigame.pre_action(adventurer_id);
-            let (game_systems_address, _) = world.dns(@"game_systems").unwrap();
-            let game_systems = IGameSystemsDispatcher { contract_address: game_systems_address };
-            game_systems.buy_items(adventurer_id, potions, items);
-            self.minigame.post_action(adventurer_id);
-        }
-
-        fn select_stat_upgrades(ref self: ContractState, adventurer_id: u64, stat_upgrades: Stats) {
-            let mut world: WorldStorage = self.world(@DEFAULT_NS());
-            self.minigame.pre_action(adventurer_id);
-            let (game_systems_address, _) = world.dns(@"game_systems").unwrap();
-            let game_systems = IGameSystemsDispatcher { contract_address: game_systems_address };
-            game_systems.select_stat_upgrades(adventurer_id, stat_upgrades);
-            self.minigame.post_action(adventurer_id);
-        }
-
         fn create_objective(ref self: ContractState, score: u32) {
             let mut world: WorldStorage = self.world(@DEFAULT_NS());
             let objective_count_model: ScoreObjectiveCount = world.read_model(VERSION);

--- a/contracts/src/systems/settings/contracts.cairo
+++ b/contracts/src/systems/settings/contracts.cairo
@@ -46,6 +46,7 @@ mod settings_systems {
     use openzeppelin_introspection::src5::SRC5Component;
     use starknet::ContractAddress;
     use super::ISettingsSystems;
+    use death_mountain::utils::renderer::encoding::U256BytesUsedTraitImpl;
 
     component!(path: SettingsComponent, storage: settings, event: SettingsEvent);
     component!(path: SRC5Component, storage: src5, event: SRC5Event);
@@ -147,12 +148,22 @@ mod settings_systems {
             let (game_token_systems_address, _) = world.dns(@"game_token_systems").unwrap();
             let minigame_dispatcher = IMinigameDispatcher { contract_address: game_token_systems_address };
             let minigame_token_address = minigame_dispatcher.token_address();
+
+            let mut _name = Default::default();
+
+            if name != 0 {
+                _name
+                    .append_word(
+                        name, U256BytesUsedTraitImpl::bytes_used(name.into()).into()
+                    );
+            }
+
             self
                 .settings
                 .create_settings(
                     game_token_systems_address,
                     settings_count.count,
-                    format!("{}", name),
+                    _name,
                     description.clone(),
                     settings,
                     minigame_token_address,

--- a/contracts/src/systems/settings/contracts.cairo
+++ b/contracts/src/systems/settings/contracts.cairo
@@ -34,6 +34,7 @@ mod settings_systems {
     use death_mountain::models::adventurer::bag::{Bag, ImplBag};
     use death_mountain::models::adventurer::equipment::{IEquipment, ImplEquipment};
     use death_mountain::models::game::{GameSettings, GameSettingsMetadata, SettingsCounter, StatsMode};
+    use death_mountain::utils::renderer::encoding::U256BytesUsedTraitImpl;
 
     use dojo::model::ModelStorage;
     use dojo::world::{WorldStorage, WorldStorageTrait};
@@ -46,7 +47,6 @@ mod settings_systems {
     use openzeppelin_introspection::src5::SRC5Component;
     use starknet::ContractAddress;
     use super::ISettingsSystems;
-    use death_mountain::utils::renderer::encoding::U256BytesUsedTraitImpl;
 
     component!(path: SettingsComponent, storage: settings, event: SettingsEvent);
     component!(path: SRC5Component, storage: src5, event: SRC5Event);
@@ -152,10 +152,7 @@ mod settings_systems {
             let mut _name = Default::default();
 
             if name != 0 {
-                _name
-                    .append_word(
-                        name, U256BytesUsedTraitImpl::bytes_used(name.into()).into()
-                    );
+                _name.append_word(name, U256BytesUsedTraitImpl::bytes_used(name.into()).into());
             }
 
             self


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Network selector on desktop and mobile with online/offline status and persistent choice.

- Changes
  - Default network set to “Beast Mode” (Sepolia); “Practice Mode” available via selector.
  - Dynamic network name shown across menus; WalletConnect always visible and login flow streamlined.
  - Adventurers list UI/icons updated; branding changed to “Provable Games”.
  - Removed Practice button and the previous unauthenticated "Play Practice" option.

- Chores
  - Upgraded tooling and contract configurations; dependency version bumps.
  - Expanded .gitignore to exclude env and account files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->