### PR TITLE
feat: add optional renderer address parameter to dojo_init

### DIFF
--- a/contracts/dojo_sepolia.toml
+++ b/contracts/dojo_sepolia.toml
@@ -22,5 +22,6 @@ default = "ls_0_0_6"
 [init_call_args]
 "ls_0_0_6-game_token_systems" = [
     "0x065d2AB17338b5AffdEbAF95E2D79834B5f30Bac596fF55563c62C3c98700150", # account address
-    "0x06a1102ed881e0d6d689295db5819dd1d15f0d55cbe10e1b87587c2ea1ec8da4" # denshokan address
+    "0x06a1102ed881e0d6d689295db5819dd1d15f0d55cbe10e1b87587c2ea1ec8da4", # denshokan address
+    "1" # Option::None for renderer address
 ]

--- a/contracts/dojo_slot.toml
+++ b/contracts/dojo_slot.toml
@@ -25,5 +25,6 @@ default = "ls_0_0_4"
 [init_call_args]
 "ls_0_0_4-game_token_systems" = [
     "0x0238df9Efd27Aba2ccB0bdC97a4cf440caA403e9ed3f1883294Ab6CDBA6C5282",
-    "0x004311c2b0845051fc5c703ec1792a36f99272e3400953632d62b3dac68f8598" # denshokan_address
+    "0x004311c2b0845051fc5c703ec1792a36f99272e3400953632d62b3dac68f8598", # denshokan_address
+    "1" # Option::None for renderer address
 ]

--- a/contracts/src/systems/game/contracts.cairo
+++ b/contracts/src/systems/game/contracts.cairo
@@ -1744,7 +1744,7 @@ mod tests {
     use death_mountain::systems::loot::contracts::{ILootSystemsDispatcherTrait, loot_systems};
     use death_mountain::systems::renderer::contracts::renderer_systems;
     use death_mountain::systems::settings::contracts::settings_systems;
-    use dojo::model::{ModelStorage, ModelStorageTest, ModelValueStorage};
+    use dojo::model::{ModelStorage, ModelStorageTest};
     use dojo::world::{IWorldDispatcherTrait, WorldStorage, WorldStorageTrait};
     use dojo_cairo_test::{
         ContractDef, ContractDefTrait, NamespaceDef, TestResource, WorldStorageTestTrait, spawn_test_world,
@@ -1783,6 +1783,7 @@ mod tests {
         let mut game_token_init_calldata: Array<felt252> = array![];
         game_token_init_calldata.append(contract_address_const::<'player1'>().into()); // creator_address
         game_token_init_calldata.append(denshokan_address.into()); // denshokan_address
+        game_token_init_calldata.append(1); // Option::None for renderer address
         [
             ContractDefTrait::new(@DEFAULT_NS(), @"game_systems")
                 .with_writer_of([dojo::utils::bytearray_hash(@DEFAULT_NS())].span()),
@@ -2071,7 +2072,7 @@ mod tests {
     #[test]
     #[should_panic(expected: ('Market item does not exist', 'ENTRYPOINT_FAILED'))]
     fn buy_item_not_on_market() {
-        let (world, game, game_libs, _) = deploy_dungeon();
+        let (world, game, _, _) = deploy_dungeon();
         let adventurer_id = new_game(world, game);
 
         // take out starter beast

--- a/contracts/src/systems/game_token/contracts.cairo
+++ b/contracts/src/systems/game_token/contracts.cairo
@@ -68,10 +68,25 @@ mod game_token_systems {
     /// deployed.
     ///
     /// @param creator_address: the address of the creator of the game
-    fn dojo_init(ref self: ContractState, creator_address: ContractAddress, denshokan_address: ContractAddress) {
+    /// @param denshokan_address: the address of the denshokan contract
+    /// @param renderer_address: optional renderer address, defaults to 'renderer_systems' if None
+    fn dojo_init(
+        ref self: ContractState,
+        creator_address: ContractAddress,
+        denshokan_address: ContractAddress,
+        renderer_address: Option<ContractAddress>,
+    ) {
         let mut world: WorldStorage = self.world(@DEFAULT_NS());
         let (settings_systems_address, _) = world.dns(@"settings_systems").unwrap();
-        let (renderer_address, _) = world.dns(@"renderer_systems").unwrap();
+
+        // Use provided renderer address or default to 'renderer_systems'
+        let final_renderer_address = match renderer_address {
+            Option::Some(addr) => addr,
+            Option::None => {
+                let (default_renderer, _) = world.dns(@"renderer_systems").unwrap();
+                default_renderer
+            },
+        };
 
         self
             .minigame
@@ -85,7 +100,7 @@ mod game_token_systems {
                 "https://deathmountain.gg/favicon.png",
                 Option::None, // color
                 Option::None, // client_url
-                Option::Some(renderer_address), // renderer address
+                Option::Some(final_renderer_address), // renderer address
                 Option::Some(settings_systems_address), // settings_address
                 Option::Some(get_contract_address()), // objectives_address
                 denshokan_address,


### PR DESCRIPTION
- Update dojo_init function to accept optional renderer_address parameter
- Use provided renderer address if available, otherwise default to 'renderer_systems'
- Maintains backward compatibility while allowing custom renderer configuration