### PR TITLE
fix: remove explicit policies on mainnet

### DIFF
--- a/client/src/utils/networkConfig.ts
+++ b/client/src/utils/networkConfig.ts
@@ -261,8 +261,6 @@ export function getNetworkConfig(networkKey: ChainId): NetworkConfig {
     },
   ];
 
-  console.log({ policies });
-
   return {
     chainId: network.chainId,
     name: network.name,
@@ -272,7 +270,7 @@ export function getNetworkConfig(networkKey: ChainId): NetworkConfig {
     slot: network.slot,
     preset: "loot-survivor",
     vrf: network.vrf,
-    policies: network.chainId === ChainId.SN_MAIN ? undefined : policies,
+    policies,
     rpcUrl: network.rpcUrl,
     toriiUrl: network.torii,
     chains: [{ rpcUrl: network.rpcUrl }],

--- a/client/src/utils/networkConfig.ts
+++ b/client/src/utils/networkConfig.ts
@@ -14,7 +14,7 @@ export interface NetworkConfig {
   policies: Array<{
     target: string;
     method: string;
-  }>;
+  }> | undefined;
   vrf: boolean;
   rpcUrl: string;
   toriiUrl: string;
@@ -197,7 +197,7 @@ export function getNetworkConfig(networkKey: ChainId): NetworkConfig {
   const vrf_provider = import.meta.env.VITE_PUBLIC_VRF_PROVIDER_ADDRESS;
 
   // Base policies that are common across networks
-  const policies = [
+  const policies = network.chainId === ChainId.SN_MAIN ? undefined : [
     {
       target:
         "0x025ff15ffd980fa811955d471abdf0d0db40f497a0d08e1fedd63545d1f7ab0d",
@@ -261,6 +261,8 @@ export function getNetworkConfig(networkKey: ChainId): NetworkConfig {
     },
   ];
 
+  console.log({ policies });
+
   return {
     chainId: network.chainId,
     name: network.name,
@@ -270,7 +272,7 @@ export function getNetworkConfig(networkKey: ChainId): NetworkConfig {
     slot: network.slot,
     preset: "loot-survivor",
     vrf: network.vrf,
-    policies,
+    policies: network.chainId === ChainId.SN_MAIN ? undefined : policies,
     rpcUrl: network.rpcUrl,
     toriiUrl: network.torii,
     chains: [{ rpcUrl: network.rpcUrl }],


### PR DESCRIPTION
On mainnet you need to provide `undefined` policies to actually use those fetched from the LS presets
It will prevent this validation screen for players
<img width="884" height="1220" alt="image" src="https://github.com/user-attachments/assets/bd7ebf78-4622-40c9-8bf5-6c8666b17098" />
